### PR TITLE
initial code refactoring

### DIFF
--- a/dbldatagen/column_spec_options.py
+++ b/dbldatagen/column_spec_options.py
@@ -204,10 +204,10 @@ s
         assert name is not None, "`name` must be specified"
         if optional:
             ensure(v is None or type(v) is bool,
-                   "Option `{}` must be boolean if specified - value: {}, type: {}".format(name, v, type(v)))
+                   f"Option `{name}` must be boolean if specified - value: {v}, type: {type(v)}")
         else:
             ensure(type(v) is bool,
-                   "Option `{}` must be boolean  - value: {}, type: {}".format(name, v, type(v)))
+                   f"Option `{name}` must be boolean  - value: {v}, type: {type(v)}")
 
     def checkExclusiveOptions(self, options):
         """check if the options are exclusive - i.e only one is not None
@@ -227,8 +227,7 @@ s
         """
         assert option is not None and len(option.strip()) > 0, "option must be non empty"
         assert type(option_values) is list, "`option_values` must be list"
-        assert self[option] in option_values, "option: `{}` must have one of the values {}".format(option,
-                                                                                                   option_values)
+        assert self[option] in option_values, f"option: `{option}` must have one of the values {option_values}"
 
     def checkValidColumnProperties(self, columnProps):
         """
@@ -254,20 +253,16 @@ s
                    f"invalid column option {k}")
 
         for arg in self._REQUIRED_PROPERTIES:
-            ensure(arg in columnProps.keys() and columnProps[arg] is not None,
-                   f"missing column option {arg}")
+            ensure(columnProps.get(arg) is not None, f"missing column option {arg}")
 
         for arg in self._FORBIDDEN_PROPERTIES:
-            ensure(arg not in columnProps.keys(),
-                   f"forbidden column option {arg}")
+            ensure(arg not in columnProps, f"forbidden column option {arg}")
 
         # check weights and values
-        if 'weights' in columnProps.keys():
-            ensure('values' in columnProps.keys(),
-                   "weights are only allowed for columns with values - column '{0}' ".format(columnProps['name']))
+        if 'weights' in columnProps:
+            ensure('values' in columnProps,
+                   f"weights are only allowed for columns with values - column '{columnProps['name']}' ")
             ensure(columnProps['values'] is not None and len(columnProps['values']) > 0,
-                   "weights must be associated with non-empty list of values - column '{0}' ".format(
-                       columnProps['name']))
+                   f"weights must be associated with non-empty list of values - column '{columnProps['name']}' ")
             ensure(len(columnProps['values']) == len(columnProps['weights']),
-                   "length of list of weights must be  equal to length of list of values - column '{0}' ".format(
-                       columnProps['name']))
+                   f"length of list of weights must be  equal to length of list of values - column '{columnProps['name']}' ")

--- a/dbldatagen/data_analyzer.py
+++ b/dbldatagen/data_analyzer.py
@@ -57,7 +57,7 @@ class DataAnalyzer:
     def _summarizeField(self, field):
         """Generate summary for individual field"""
         if isinstance(field, StructField):
-            return "{} {}".format(field.name, self._lookupFieldType(str(field.dataType)))
+            return f"{field.name} {self._lookupFieldType(str(field.dataType))}"
         else:
             return str(field)
 
@@ -86,7 +86,7 @@ class DataAnalyzer:
         results = []
         row_key_pairs = row.asDict()
         for x in row_key_pairs:
-            results.append("{}: {}".format(str(x), str(row[x])))
+            results.append(f"{x}: {row[x]}")
 
         return ", ".join(results)
 

--- a/dbldatagen/data_generator.py
+++ b/dbldatagen/data_generator.py
@@ -107,7 +107,7 @@ class DataGenerator:
                 self._seedMethod = "fixed"
 
         if self._seedMethod not in [None, RANDOM_SEED_FIXED, RANDOM_SEED_HASH_FIELD_NAME]:
-            msg = f"""seedMethod should be None, '{RANDOM_SEED_FIXED}' or '{RANDOM_SEED_HASH_FIELD_NAME}' """
+            msg = f"seedMethod should be None, '{RANDOM_SEED_FIXED}' or '{RANDOM_SEED_HASH_FIELD_NAME}' "
             raise DataGenError(msg)
 
         self._columnSpecsByName = {}
@@ -256,9 +256,8 @@ class DataGenerator:
             self.computeBuildPlan()
 
         output = ["", "Data generation plan", "====================",
-                  """spec=DateGenerator(name={}, rows={}, startingId={}, partitions={})"""
-                      .format(self.name, self._rowCount, self.starting_id, self.partitions), ")", "",
-                  "column build order: {}".format(self._buildOrder), "", "build plan:"]
+                  f"spec=DateGenerator(name={self.name}, rows={self._rowCount}, startingId={self.starting_id}, partitions={self.partitions})"
+                  , ")", "", f"column build order: {self._buildOrder}", "", "build plan:"]
 
         for plan_action in self._buildPlan:
             output.append(" ==> " + plan_action)
@@ -576,10 +575,10 @@ class DataGenerator:
         if type(columns) is list:
             for column in columns:
                 ensure(column in inferred_columns,
-                       " column `{0}` must refer to defined column".format(column))
+                       f" column `{column}` must refer to defined column")
         else:
             ensure(columns in inferred_columns,
-                   " column `{0}` must refer to defined column".format(columns))
+                   f" column `{columns}` must refer to defined column")
         return True
 
     def withColumnSpec(self, colName, minValue=None, maxValue=None, step=1, prefix=None,
@@ -595,19 +594,19 @@ class DataGenerator:
 
         """
         ensure(colName is not None, "Must specify column name for column")
-        ensure(colName in self.getInferredColumnNames(), " column `{0}` must refer to defined column".format(colName))
+        ensure(colName in self.getInferredColumnNames(), f" column `{colName}` must refer to defined column")
         if baseColumn is not None:
             self._checkColumnOrColumnList(baseColumn)
-        ensure(not self.isFieldExplicitlyDefined(colName), "duplicate column spec for column `{0}`".format(colName))
+        ensure(not self.isFieldExplicitlyDefined(colName), f"duplicate column spec for column `{colName}`")
 
         # handle migration of old `min` and `max` options
-        if _OLD_MIN_OPTION in kwargs.keys():
+        if _OLD_MIN_OPTION in kwargs:
             assert minValue is None, \
                 "Only one of `minValue` and `minValue` can be specified. Use of `minValue` is preferred"
             minValue = kwargs[_OLD_MIN_OPTION]
             kwargs.pop(_OLD_MIN_OPTION, None)
 
-        if _OLD_MAX_OPTION in kwargs.keys():
+        if _OLD_MAX_OPTION in kwargs:
             assert maxValue is None, \
                 "Only one of `maxValue` and `maxValue` can be specified. Use of `maxValue` is preferred"
             maxValue = kwargs[_OLD_MAX_OPTION]
@@ -632,7 +631,7 @@ class DataGenerator:
         :param colName: name of column to check for
         :returns: True if column has spec, False otherwise
         """
-        return colName in self._columnSpecsByName.keys()
+        return colName in self._columnSpecsByName
 
     def withColumn(self, colName, colType=StringType(), minValue=None, maxValue=None, step=1,
                    dataRange=None, prefix=None, random=False, distribution=None,
@@ -649,18 +648,18 @@ class DataGenerator:
 
         """
         ensure(colName is not None, "Must specify column name for column")
-        ensure(colType is not None, "Must specify column type for column `{0}`".format(colName))
+        ensure(colType is not None, f"Must specify column type for column `{colName}`")
         if baseColumn is not None:
             self._checkColumnOrColumnList(baseColumn, allowId=True)
 
         # handle migration of old `min` and `max` options
-        if _OLD_MIN_OPTION in kwargs.keys():
+        if _OLD_MIN_OPTION in kwargs:
             assert minValue is None, \
                 "Only one of `minValue` and `minValue` can be specified. Use of `minValue` is preferred"
             minValue = kwargs[_OLD_MIN_OPTION]
             kwargs.pop(_OLD_MIN_OPTION, None)
 
-        if _OLD_MAX_OPTION in kwargs.keys():
+        if _OLD_MAX_OPTION in kwargs:
             assert maxValue is None, \
                 "Only one of `maxValue` and `maxValue` can be specified. Use of `maxValue` is preferred"
             maxValue = kwargs[_OLD_MAX_OPTION]
@@ -765,8 +764,7 @@ class DataGenerator:
         id_partitions = self.partitions if self.partitions is not None else 4
 
         if not streaming:
-            status = ("Generating data frame with ids from {} to {} with {} partitions"
-                      .format(startId, end_id, id_partitions))
+            status = (f"Generating data frame with ids from {startId} to {end_id} with {id_partitions} partitions")
             self.logger.info(status)
             self.executionHistory.append(status)
             df1 = self.sparkSession.range(start=startId,
@@ -777,8 +775,7 @@ class DataGenerator:
                 df1 = df1.withColumnRenamed("id", ColumnGenerationSpec.SEED_COLUMN)
 
         else:
-            status = ("Generating streaming data frame with ids from {} to {} with {} partitions"
-                      .format(startId, end_id, id_partitions))
+            status = (f"Generating streaming data frame with ids from {startId} to {end_id} with {id_partitions} partitions")
             self.logger.info(status)
             self.executionHistory.append(status)
 
@@ -858,7 +855,7 @@ class DataGenerator:
         self._buildPlan = []
         self.executionHistory = []
         self._processOptions()
-        self._buildPlan.append("Build Spark data frame with seed column: {}".format(ColumnGenerationSpec.SEED_COLUMN))
+        self._buildPlan.append(f"Build Spark data frame with seed column: {ColumnGenerationSpec.SEED_COLUMN}")
 
         # add temporary columns
         for cs in self._allColumnSpecs:
@@ -869,7 +866,7 @@ class DataGenerator:
             for tmp_col in cs.temporaryColumns:
                 # create column spec for temporary column if its not already present
                 if not self.hasColumnSpec(tmp_col[0]):
-                    self._buildPlan.append("materializing temporary column {}".format(tmp_col[0]))
+                    self._buildPlan.append(f"materializing temporary column {tmp_col[0]}")
                     self.withColumn(tmp_col[0], tmp_col[1], **tmp_col[2])
 
         # TODO: set up the base column data type information
@@ -923,7 +920,7 @@ class DataGenerator:
         df1 = self._buildColumnExpressionsWithSelects(df1)
 
         df1 = df1.select(*self.getOutputColumnNames())
-        self.executionHistory.append("selecting columns: {}".format(self.getOutputColumnNames()))
+        self.executionHistory.append(f"selecting columns: {self.getOutputColumnNames()}")
 
         # register temporary or global views if necessary
         if withView:
@@ -951,7 +948,7 @@ class DataGenerator:
         for colNames in self.build_order:
             build_round = ["*"]
             inx_col = 0
-            self.executionHistory.append("building stage for columns: {}".format(colNames))
+            self.executionHistory.append(f"building stage for columns: {colNames}")
             for colName in colNames:
                 col1 = self._columnSpecsByName[colName]
                 column_generators = col1.makeGenerationExpressions()
@@ -961,7 +958,7 @@ class DataGenerator:
                 elif type(column_generators) is list and len(column_generators) > 1:
                     i = 0
                     for cg in column_generators:
-                        build_round.append(cg.alias('{0}_{1}'.format(colName, i)))
+                        build_round.append(cg.alias(f'{colName}_{i}'))
                         i += 1
                 else:
                     build_round.append(column_generators.alias(colName))
@@ -982,16 +979,16 @@ class DataGenerator:
         results = []
         subs = {}
         for x in columns:
-            subs[x] = "{}.{}".format(srcAlias, x)
+            subs[x] = f"{srcAlias}.{x}"
         for x in substitutions:
             subs[x[0]] = x[1]
 
         for substitution_col in columns:
             new_val = subs[substitution_col]
             if isUpdate:
-                results.append("{}={}".format(substitution_col, new_val))
+                results.append(f"{substitution_col}={new_val}")
             else:
-                results.append("{}".format(new_val))
+                results.append(f"{new_val}")
 
         return ", ".join(results)
 
@@ -1010,7 +1007,7 @@ class DataGenerator:
 
         output_columns = self.getOutputColumnNamesAndTypes()
 
-        results = ["CREATE TABLE IF NOT EXISTS {} (".format(name)]
+        results = [f"CREATE TABLE IF NOT EXISTS {name} ("]
         ensure(output_columns is not None and len(output_columns) > 0,
                """
                 | You must specify at least one column for output
@@ -1019,13 +1016,13 @@ class DataGenerator:
 
         col_expressions = []
         for col_to_output in output_columns:
-            col_expressions.append("    {} {}".format(col_to_output[0], self._sqlTypeFromSparkType(col_to_output[1])))
+            col_expressions.append(f"    {col_to_output[0]} {self._sqlTypeFromSparkType(col_to_output[1])}")
         results.append(",\n".join(col_expressions))
         results.append(")")
-        results.append("using {}".format(tableFormat))
+        results.append(f"using {tableFormat}")
 
         if location is not None:
-            results.append("location '{}'".format(location))
+            results.append(f"location '{location}'")
 
         return "\n".join(results)
 
@@ -1086,23 +1083,23 @@ class DataGenerator:
             updateColumns = output_columns
 
         # build merge statement
-        results = ["MERGE INTO `{}` as {}".format(tgtName, tgtAlias)]
+        results = [f"MERGE INTO `{tgtName}` as {tgtAlias}"]
 
         # use time expression if supplied
         if timeExpr is None:
-            results.append("USING `{}` as {}".format(srcName, srcAlias))
+            results.append(f"USING `{srcName}` as {srcAlias}")
         else:
-            results.append("USING `{}` {} as {}".format(srcName, timeExpr, srcAlias))
+            results.append(f"USING `{srcName}` {timeExpr} as {srcAlias}")
 
         # add join condition
-        results.append("ON {}".format(joinExpr))
+        results.append(f"ON {joinExpr}")
 
         # generate update clause
         update_clause = None
         if updateExpr is not None:
-            update_clause = """WHEN MATCHED and {} THEN UPDATE """.format(updateExpr)
+            update_clause = f"WHEN MATCHED and {updateExpr} THEN UPDATE "
         else:
-            update_clause = """WHEN MATCHED THEN UPDATE """
+            update_clause = "WHEN MATCHED THEN UPDATE "
 
         if not useExplicitNames:
             update_clause = update_clause + " SET *"
@@ -1116,22 +1113,21 @@ class DataGenerator:
 
         # generate delete clause
         if delExpr is not None:
-            results.append("WHEN MATCHED and {} THEN DELETE".format(delExpr))
+            results.append(f"WHEN MATCHED and {delExpr} THEN DELETE")
 
         if insertExpr is not None:
-            ins_clause = "WHEN NOT MATCHED and {} THEN INSERT ".format(insertExpr)
+            ins_clause = f"WHEN NOT MATCHED and {insertExpr} THEN INSERT "
         else:
             ins_clause = "WHEN NOT MATCHED THEN INSERT "
 
         if not useExplicitNames:
             ins_clause = ins_clause + " *"
         else:
-            ins_clause = (ins_clause
-                          + "({})".format(",".join(insertColumns))
-                          + " VALUES ({})".format(self._mkInsertOrUpdateStatement(columns=insertColumns,
-                                                                                  srcAlias=srcAlias,
-                                                                                  substitutions=insertColumnExprs,
-                                                                                  isUpdate=False))
+            ins_clause = (ins_clause + "(" + ",".join(insertColumns)
+                          + ") VALUES (" +
+                          self._mkInsertOrUpdateStatement(columns=insertColumns, srcAlias=srcAlias,
+                                                          substitutions=insertColumnExprs, isUpdate=False)
+                          + ")"
                           )
 
         results.append(ins_clause)

--- a/dbldatagen/daterange.py
+++ b/dbldatagen/daterange.py
@@ -122,8 +122,7 @@ class DateRange(DataRange):
 
     def __str__(self):
         """ create string representation of date range"""
-        return "DateRange({},{},{} == {}, {}, {})".format(self.begin, self.end, self.interval,
-                                                          self.minValue, self.maxValue, self.step)
+        return f"DateRange({self.begin},{self.end},{self.interval} == {self.minValue}, {self.maxValue}, {self.step})"
 
     def computeTimestampIntervals(self, start, end, interval):
         """ Compute number of intervals between start and end date """

--- a/dbldatagen/distributions/beta.py
+++ b/dbldatagen/distributions/beta.py
@@ -37,8 +37,7 @@ class Beta(DataDistribution):
 
     def __str__(self):
         """ Return string representation of object"""
-        return ("BetaDistribution(alpha={}, beta={}, randomSeed={})"
-                .format(self._alpha, self._beta, self.randomSeed))
+        return (f"BetaDistribution(alpha={self._alpha}, beta={self._beta}, randomSeed={self.randomSeed})")
 
     @staticmethod
     def beta_func(alpha_series: pd.Series, beta_series: pd.Series, random_seed: pd.Series) -> pd.Series:

--- a/dbldatagen/distributions/exponential_distribution.py
+++ b/dbldatagen/distributions/exponential_distribution.py
@@ -32,8 +32,7 @@ class Exponential(DataDistribution):
 
     def __str__(self):
         """ Return string representation"""
-        return ("{}(rate={}, randomSeed={})"
-                .format("ExponentialDistribution", self.rate, self.randomSeed))
+        return (f"ExponentialDistribution(rate={self.rate}, randomSeed={self.randomSeed})")
 
     @staticmethod
     def exponential_func(scale_series: pd.Series, random_seed: pd.Series) -> pd.Series:

--- a/dbldatagen/distributions/gamma.py
+++ b/dbldatagen/distributions/gamma.py
@@ -36,8 +36,7 @@ class Gamma(DataDistribution):
 
     def __str__(self):
         """ Return string representation of object """
-        return ("GammaDistribution(shape(`k`)={}, scale(`theta`)={}, randomSeed={})"
-                .format(self._shape, self._scale, self.randomSeed))
+        return (f"GammaDistribution(shape(`k`)={self._shape}, scale(`theta`)={self._scale}, randomSeed={self.randomSeed})")
 
     @staticmethod
     def gamma_func(shape_series: pd.Series, scale_series: pd.Series, random_seed: pd.Series) -> pd.Series:

--- a/dbldatagen/distributions/normal_distribution.py
+++ b/dbldatagen/distributions/normal_distribution.py
@@ -72,8 +72,7 @@ class Normal(DataDistribution):
 
     def __str__(self):
         """ Return string representation of object """
-        return ("NormalDistribution( mean={}, stddev={}, randomSeed={})"
-                .format( self.mean, self.stddev, self.randomSeed))
+        return (f"NormalDistribution( mean={self.mean}, stddev={self.stddev}, randomSeed={self.randomSeed})")
 
     @classmethod
     def standardNormal(cls):

--- a/dbldatagen/function_builder.py
+++ b/dbldatagen/function_builder.py
@@ -95,12 +95,14 @@ class ColumnGeneratorBuilder:
         conditions = zip(values, cdf_probs)
 
         for v, cdf in conditions:
+            # TODO(alex): single quotes needs to be escaped
             if isinstance(datatype, (StringType, DateType, TimestampType)):
-                output.append(" when {} <= {} then '{}' ".format(seed_column, cdf, v))
+                output.append(f" when {seed_column} <= {cdf} then '{v}' ")
             else:
-                output.append(" when {} <= {} then {} ".format(seed_column, cdf, v))
+                output.append(f" when {seed_column} <= {cdf} then {v} ")
 
-        output.append("else '{}'".format(values[-1]))
+        # TODO(alex): single quotes needs to be escaped
+        output.append("else '{values[-1]}'")
         output.append("end")
 
         retval = "\n".join(output)

--- a/dbldatagen/nrange.py
+++ b/dbldatagen/nrange.py
@@ -36,7 +36,7 @@ class NRange(DataRange):
 
     def __init__(self, minValue=None, maxValue=None, step=None, until=None, **kwArgs):
         # check if older form of `minValue` and `maxValue` are used, and if so
-        if _OLD_MIN_OPTION in kwArgs.keys():
+        if _OLD_MIN_OPTION in kwArgs:
             assert minValue is None, \
                 "Only one of `minValue` and `minValue` can be specified. Use of `minValue` is preferred"
             self.minValue = kwArgs[_OLD_MIN_OPTION]
@@ -44,7 +44,7 @@ class NRange(DataRange):
         else:
             self.minValue = minValue
 
-        if _OLD_MAX_OPTION in kwArgs.keys():
+        if _OLD_MAX_OPTION in kwArgs:
             assert maxValue is None, \
                 "Only one of `maxValue` and `maxValue` can be specified. Use of `maxValue` is preferred"
             self.maxValue = kwArgs[_OLD_MAX_OPTION]
@@ -61,7 +61,7 @@ class NRange(DataRange):
         self.step = step
 
     def __str__(self):
-        return "NRange({}, {}, {})".format(self.minValue, self.maxValue, self.step)
+        return f"NRange({self.minValue}, {self.maxValue}, {self.step})"
 
     def isEmpty(self):
         """Check if object is empty (i.e all instance vars of note are `None`

--- a/dbldatagen/schema_parser.py
+++ b/dbldatagen/schema_parser.py
@@ -105,12 +105,12 @@ class SchemaParser(object):
         else:
             raise ValueError("Table name could not be found")
 
-        sparkSession.sql("create temporary table {}{}using csv".format(table_name, table_body))
+        sparkSession.sql(f"create temporary table {table_name}{table_body}using csv")
 
-        result = sparkSession.sql("select * from {}".format(table_name))
+        result = sparkSession.sql(f"select * from {table_name}")
         result.printSchema()
         result_schema = result.schema
 
-        sparkSession.sql("drop table {}".format(table_name))
+        sparkSession.sql(f"drop table {table_name}")
 
         return result_schema

--- a/dbldatagen/spark_singleton.py
+++ b/dbldatagen/spark_singleton.py
@@ -38,7 +38,7 @@ class SparkSingleton:
         logging.info("cpu count: %d", cpu_count)
 
         return SparkSession.builder \
-            .master("local[{}]".format(cpu_count)) \
+            .master(f"local[{cpu_count}]") \
             .appName(appName) \
             .config("spark.sql.warehouse.dir", "/tmp/spark-warehouse") \
             .getOrCreate()

--- a/dbldatagen/utils.py
+++ b/dbldatagen/utils.py
@@ -24,7 +24,7 @@ def deprecated(message=""):
     def deprecated_decorator(func):
         @functools.wraps(func)
         def deprecated_func(*args, **kwargs):
-            warnings.warn("`{}` is a deprecated function or method. \n{}".format(func.__name__, message),
+            warnings.warn(f"`{func.__name__}` is a deprecated function or method. \n{message}",
                           category=DeprecationWarning, stacklevel=1)
             warnings.simplefilter('default', DeprecationWarning)
             return func(*args, **kwargs)

--- a/tests/test_pandas_integration.py
+++ b/tests/test_pandas_integration.py
@@ -58,7 +58,7 @@ class TestPandasIntegration(unittest.TestCase):
         print("numpy version ", np.version)
 
         # Enable Arrow-based columnar data transfers
-        spark.conf.set("spark.sql.execution.arrow.enabled", "true")
+        spark.conf.set("spark.sql.execution.arrow.pyspark.enabled", "true")
 
         # Generate a Pandas DataFrame
         pdf = pd.DataFrame(np.random.rand(100, 3))

--- a/tests/test_text_generation.py
+++ b/tests/test_text_generation.py
@@ -33,7 +33,7 @@ schema = StructType([
 spark = dg.SparkSingleton.getLocalInstance("unit tests")
 
 spark.conf.set("spark.sql.execution.arrow.maxRecordsPerBatch", "500")
-spark.conf.set("spark.sql.execution.arrow.enabled", "true")
+spark.conf.set("spark.sql.execution.arrow.pyspark.enabled", "true")
 
 
 # Test manipulation and generation of test data for a large schema


### PR DESCRIPTION
Changes include:
* Using the f-strings instead of `.format` that is harder to read
* Use `key in dict` instead of `key in dict.keys()`
* Fix warning in tests about deprecated Spark property for Arrow