### PR TITLE
exposed __version__ attribute for library

### DIFF
--- a/dbldatagen/__init__.py
+++ b/dbldatagen/__init__.py
@@ -27,6 +27,7 @@ from .data_generator import DataGenerator
 from .datagen_constants import DEFAULT_RANDOM_SEED, RANDOM_SEED_RANDOM, RANDOM_SEED_FIXED, RANDOM_SEED_HASH_FIELD_NAME
 from .utils import ensure, topologicalSort, mkBoundsList, coalesce_values, \
     deprecated, parse_time_interval, DataGenError
+from ._version import __version__
 from .column_generation_spec import ColumnGenerationSpec
 from .column_spec_options import ColumnSpecOptions
 from .data_analyzer import DataAnalyzer

--- a/dbldatagen/_version.py
+++ b/dbldatagen/_version.py
@@ -21,8 +21,11 @@ VersionInfo = namedtuple('VersionInfo', ['major', 'minor', 'patch', 'release', '
 
 
 def get_version(version):
-    """ Get version string for library.
-    Layout should be compatible with `bump` package"""
+    """ Get version info object for library.
+
+    :param version: version string to parse for version information
+
+    Layout of version string must be compatible with `bump` package"""
     r = re.compile(r'(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\-{0,1}(?P<release>\D*)(?P<build>\d*)')
     major, minor, patch, release, build = r.match(version).groups()
     version_info = VersionInfo(major, minor, patch, release, build)

--- a/tests/test_basic_test.py
+++ b/tests/test_basic_test.py
@@ -354,6 +354,14 @@ class TestBasicOperation(unittest.TestCase):
         self.assertLessEqual( percent_nulls_observed, 15.0)
         self.assertGreaterEqual( percent_nulls_observed, 5.0)
 
+    def test_library_version(self):
+        lib_version = dg.__version__
+
+        self.assertIsNotNone(lib_version)
+        self.assertTrue(type(lib_version) == str, "__version__ is expected to be a string")
+        self.assertTrue(len(lib_version.strip()) > 0, "__version__ is expected to be non-empty")
+
+
 
 # run the tests
 # if __name__ == '__main__':


### PR DESCRIPTION
make __version__ attribute public

## Proposed changes

Expose __version__ to allow rerporting of library version following PEP8 conventions

## Types of changes

What types of changes does your code introduce to dbldatagen?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Change to tutorials, tests or examples
- [ ] Non code change (readme, images or other non-code assets)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. 
If you're unsure about any of them, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code._

- [ ] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Submission does not reduce code coverage numbers
- [ ] Submission does not increase alerts or messages from LGTM

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you 
did and what alternatives you considered, etc...