### PR TITLE
Fix data ranges for random data generation

### DIFF
--- a/dbldatagen/nrange.py
+++ b/dbldatagen/nrange.py
@@ -15,18 +15,6 @@ from .datarange import DataRange
 
 _OLD_MIN_OPTION = 'min'
 _OLD_MAX_OPTION = 'max'
-_MIN_BYTE_VALUE = -(2**4 - 1)
-_MAX_BYTE_VALUE = (2**4 - 1)
-_MIN_SHORT_VALUE = -(2**8 - 1)
-_MAX_SHORT_VALUE = (2**8 - 1)
-_MIN_INT_VALUE = -(2**16 - 1)
-_MAX_INT_VALUE = (2**16 - 1)
-_MIN_LONG_VALUE = -(2**32 - 1)
-_MAX_LONG_VALUE = (2**32 - 1)
-_MIN_FLOAT_VALUE = -3.402e38
-_MAX_FLOAT_VALUE = 3.402e38
-_MIN_DOUBLE_VALUE = -1.79769e308
-_MAX_DOUBLE_VALUE = 1.79769e308
 
 
 class NRange(DataRange):
@@ -95,47 +83,12 @@ class NRange(DataRange):
         :param ctype: Spark SQL type instance to adjust range for
         :returns: No return value - executes for effect only
         """
-        if type(ctype) is DecimalType:
+        numeric_types = [DecimalType, FloatType, DoubleType, ByteType, ShortType, IntegerType, LongType]
+        if type(ctype) in numeric_types:
             if self.minValue is None:
-                self.minValue = 0.0
+                self.minValue = NRange._getNumericDataTypeRange(ctype)[0]
             if self.maxValue is None:
-                self.maxValue = math.pow(10, ctype.precision - ctype.scale) - 1.0
-
-        if type(ctype) is FloatType:
-            if self.minValue is None:
-                self.minValue = _MIN_FLOAT_VALUE
-            if self.maxValue is None:
-                self.maxValue = _MAX_FLOAT_VALUE
-
-        if type(ctype) is DoubleType:
-            if self.minValue is None:
-                self.minValue = _MIN_DOUBLE_VALUE
-            if self.maxValue is None:
-                self.maxValue = _MAX_DOUBLE_VALUE
-
-        if type(ctype) is ByteType:
-            if self.minValue is None:
-                self.minValue = _MIN_BYTE_VALUE
-            if self.maxValue is None:
-                self.maxValue = _MAX_BYTE_VALUE
-
-        if type(ctype) is ShortType:
-            if self.minValue is None:
-                self.minValue = _MIN_SHORT_VALUE
-            if self.maxValue is None:
-                self.maxValue = _MAX_SHORT_VALUE
-
-        if type(ctype) is IntegerType:
-            if self.minValue is None:
-                self.minValue = _MIN_INT_VALUE
-            if self.maxValue is None:
-                self.maxValue = _MAX_INT_VALUE
-
-        if type(ctype) is LongType:
-            if self.minValue is None:
-                self.minValue = _MIN_LONG_VALUE
-            if self.maxValue is None:
-                self.maxValue = _MAX_LONG_VALUE
+                self.maxValue = NRange._getNumericDataTypeRange(ctype)[1]
 
         if type(ctype) is ShortType and self.maxValue is not None:
             assert self.maxValue <= 65536, "`maxValue` must be in range of short"
@@ -191,7 +144,8 @@ class NRange(DataRange):
         # return maximum scale of components
         return max(smin, smax, sstep)
 
-    def _precision_and_scale(self, x):
+    @staticmethod
+    def _precision_and_scale(x):
         max_digits = 14
         int_part = int(abs(x))
         magnitude = 1 if int_part == 0 else int(math.log10(int_part)) + 1
@@ -204,3 +158,17 @@ class NRange(DataRange):
             frac_digits /= 10
         scale = int(math.log10(frac_digits))
         return (magnitude + scale, scale)
+
+    @staticmethod
+    def _getNumericDataTypeRange(ctype):
+        value_ranges = {
+            ByteType: (0, (2 ** 4 - 1)),
+            ShortType: (0, (2 ** 8 - 1)),
+            IntegerType: (0, (2 ** 16 - 1)),
+            LongType: (0, (2 ** 32 - 1)),
+            FloatType: (0.0, 3.402e38),
+            DoubleType: (0.0, 1.79769e308)
+        }
+        if type(ctype) is DecimalType:
+            return 0.0, math.pow(10, ctype.precision - ctype.scale) - 1.0
+        return value_ranges.get(type(ctype), None)

--- a/dbldatagen/nrange.py
+++ b/dbldatagen/nrange.py
@@ -9,12 +9,24 @@ This module defines the `NRange` class used to specify data ranges
 import math
 
 from pyspark.sql.types import LongType, FloatType, IntegerType, DoubleType, ShortType, \
-    ByteType
+    ByteType, DecimalType
 
 from .datarange import DataRange
 
 _OLD_MIN_OPTION = 'min'
 _OLD_MAX_OPTION = 'max'
+_MIN_BYTE_VALUE = -(2**4 - 1)
+_MAX_BYTE_VALUE = (2**4 - 1)
+_MIN_SHORT_VALUE = -(2**8 - 1)
+_MAX_SHORT_VALUE = (2**8 - 1)
+_MIN_INT_VALUE = -(2**16 - 1)
+_MAX_INT_VALUE = (2**16 - 1)
+_MIN_LONG_VALUE = -(2**32 - 1)
+_MAX_LONG_VALUE = (2**32 - 1)
+_MIN_FLOAT_VALUE = -3.402e38
+_MAX_FLOAT_VALUE = 3.402e38
+_MIN_DOUBLE_VALUE = -1.79769e308
+_MAX_DOUBLE_VALUE = 1.79769e308
 
 
 class NRange(DataRange):
@@ -83,13 +95,47 @@ class NRange(DataRange):
         :param ctype: Spark SQL type instance to adjust range for
         :returns: No return value - executes for effect only
         """
-        if ctype.typeName() == 'decimal':
+        if type(ctype) is DecimalType:
             if self.minValue is None:
                 self.minValue = 0.0
             if self.maxValue is None:
                 self.maxValue = math.pow(10, ctype.precision - ctype.scale) - 1.0
-            if self.step is None:
-                self.step = 1.0
+
+        if type(ctype) is FloatType:
+            if self.minValue is None:
+                self.minValue = _MIN_FLOAT_VALUE
+            if self.maxValue is None:
+                self.maxValue = _MAX_FLOAT_VALUE
+
+        if type(ctype) is DoubleType:
+            if self.minValue is None:
+                self.minValue = _MIN_DOUBLE_VALUE
+            if self.maxValue is None:
+                self.maxValue = _MAX_DOUBLE_VALUE
+
+        if type(ctype) is ByteType:
+            if self.minValue is None:
+                self.minValue = _MIN_BYTE_VALUE
+            if self.maxValue is None:
+                self.maxValue = _MAX_BYTE_VALUE
+
+        if type(ctype) is ShortType:
+            if self.minValue is None:
+                self.minValue = _MIN_SHORT_VALUE
+            if self.maxValue is None:
+                self.maxValue = _MAX_SHORT_VALUE
+
+        if type(ctype) is IntegerType:
+            if self.minValue is None:
+                self.minValue = _MIN_INT_VALUE
+            if self.maxValue is None:
+                self.maxValue = _MAX_INT_VALUE
+
+        if type(ctype) is LongType:
+            if self.minValue is None:
+                self.minValue = _MIN_LONG_VALUE
+            if self.maxValue is None:
+                self.maxValue = _MAX_LONG_VALUE
 
         if type(ctype) is ShortType and self.maxValue is not None:
             assert self.maxValue <= 65536, "`maxValue` must be in range of short"

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -218,6 +218,25 @@ class TestUseOfOptions:
         colSpec3 = ds.getColumnSpec("code3")
         assert colSpec3.random is True
 
+    def test_random3(self):
+        # will have implied column `id` for ordinal of row
+        ds = (
+            dg.DataGenerator(sparkSession=spark, name="test_dataset1", rows=500, partitions=1, random=True)
+            .withIdOutput()
+            .withColumn("val1", "decimal(5,2)", maxValue=20.0, step=0.01, random=True)
+            .withColumn("val2", "float", maxValue=20.0, random=True)
+            .withColumn("val3", "double", maxValue=20.0, random=True)
+            .withColumn("val4", "byte", maxValue=15, random=True)
+            .withColumn("val5", "short", maxValue=31, random=True)
+            .withColumn("val6", "integer", maxValue=63, random=True)
+            .withColumn("val7", "long", maxValue=127, random=True)
+        )
+
+        df = ds.build()
+        cols = ["val1", "val2", "val3", "val4", "val5", "val6", "val7"]
+        for col in cols:
+            assert df.collect() != df.orderBy(col).collect(), f"Random values were not generated for {col}"
+
     def test_random_multiple_columns(self):
         # will have implied column `id` for ordinal of row
         ds = (

--- a/tests/test_quick_tests.py
+++ b/tests/test_quick_tests.py
@@ -695,6 +695,36 @@ class TestQuickTests:
         rowCount = nullRowsDF.count()
         assert rowCount == 0
 
+    @pytest.mark.parametrize("columnSpecOptions", [
+        {"dataType": "byte", "minValue": 1, "maxValue": None},
+        {"dataType": "byte", "minValue": None, "maxValue": 10},
+        {"dataType": "short", "minValue": 1, "maxValue": None},
+        {"dataType": "short", "minValue": None, "maxValue": 100},
+        {"dataType": "integer", "minValue": 1, "maxValue": None},
+        {"dataType": "integer", "minValue": None, "maxValue": 100},
+        {"dataType": "long", "minValue": 1, "maxValue": None},
+        {"dataType": "long", "minValue": None, "maxValue": 100},
+        {"dataType": "float", "minValue": 1.0, "maxValue": None},
+        {"dataType": "float", "minValue": None, "maxValue": 100.0},
+        {"dataType": "double", "minValue": 1, "maxValue": None},
+        {"dataType": "double", "minValue": None, "maxValue": 100.0}
+    ])
+    def test_random_generation_without_range_values(self, columnSpecOptions):
+        dataType = columnSpecOptions.get("dataType", None)
+        minValue = columnSpecOptions.get("minValue", None)
+        maxValue = columnSpecOptions.get("maxValue", None)
+        testDataSpec = (dg.DataGenerator(sparkSession=spark, name="randomGenerationWithoutRangeValues", rows=100,
+                                         partitions=4)
+                        .withIdOutput()
+                        # default column type is string
+                        .withColumn("randCol", colType=dataType, minValue=minValue, maxValue=maxValue, random=True)
+                        )
+
+        df = testDataSpec.build(withTempView=True)
+        sortedDf = df.orderBy("randCol")
+        sortedVals = sortedDf.select("randCol").collect()
+        assert sortedVals != df.select("randCol").collect()
+
     def test_version_info(self):
         # test access to version info without explicit import
         print("Data generator version", dg.__version__)


### PR DESCRIPTION
## Proposed changes

Bugfix for random generation when maxValue is not specified or implied from ColumnSpecOptions. [RELATED ISSUE](https://github.com/databrickslabs/dbldatagen/issues/259)

## Types of changes

What types of changes does your code introduce to dbldatagen?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Change to tutorials, tests or examples
- [ ] Non code change (readme, images or other non-code assets)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. 
If you're unsure about any of them, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Submission does not reduce code coverage numbers
- [x] Submission does not increase alerts or messages from prospector / lint

## Further comments

I added default min or max values to the column generation options when not explicitly specified.