### PR TITLE
Add methods to create data generation specs from files

### DIFF
--- a/tests/files/test_generator_spec.json
+++ b/tests/files/test_generator_spec.json
@@ -1,0 +1,15 @@
+{
+  "generator": {
+      "name": "test_data_generator",
+      "rows": 1000,
+      "partitions": 10,
+      "randomSeedMethod": "fixed",
+      "randomSeed": 42,
+      "random": true
+  },
+  "columns": [
+      {"colName": "col1", "colType": "int", "min": 0, "max": 100},
+      {"colName": "col2", "colType": "float", "min": 0.0, "max": 100.0},
+      {"colName": "col3", "colType": "string", "values": ["a", "b", "c"], "random": true}
+  ]
+}

--- a/tests/files/test_generator_spec.txt
+++ b/tests/files/test_generator_spec.txt
@@ -1,0 +1,15 @@
+{
+  "generator": {
+      "name": "test_data_generator",
+      "rows": 1000,
+      "partitions": 10,
+      "randomSeedMethod": "fixed",
+      "randomSeed": 42,
+      "random": true
+  },
+  "columns": [
+      {"colName": "col1", "colType": "int", "min": 0, "max": 100},
+      {"colName": "col2", "colType": "float", "min": 0.0, "max": 100.0},
+      {"colName": "col3", "colType": "string", "values": ["a", "b", "c"], "random": true}
+  ]
+}

--- a/tests/files/test_generator_spec.yml
+++ b/tests/files/test_generator_spec.yml
@@ -1,0 +1,23 @@
+generator:
+  name: test_data_generator
+  rows: 1000
+  partitions: 10
+  randomSeedMethod: fixed
+  randomSeed: 42
+  random: true
+columns:
+  - colName: col1
+    colType: int
+    min: 0
+    max: 100
+  - colName: col2
+    colType: float
+    min: 0.0
+    max: 100.0
+  - colName: col3
+    colType: string
+    values:
+      - a
+      - b
+      - c
+    random: true


### PR DESCRIPTION
## Proposed changes

Added several methods to support creating `DataGenerator` and `ColumnGenerationSpec` objects from Python dictionaries and JSON/YAML files.

## Types of changes

What types of changes does your code introduce to dbldatagen?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Change to tutorials, tests or examples
- [ ] Non code change (readme, images or other non-code assets)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. 
If you're unsure about any of them, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Submission does not reduce code coverage numbers
- [x] Submission does not increase alerts or messages from prospector / lint

## Further comments

I added several methods:
- `withColumns` adds `ColumnGenerationSpec` objects via a list of dictionaries; It iteratively passes the dictionary values as arguments to `withColumn`
- `fromDict` creates a `DataGenerator` from a dictionary by passing the values as arguments to the constructor
- `fromJson` allows users to create a `DataGenerator` and add `ColumnGenerationSpecs` from a JSON file
- `fromYaml` allows users to create a `DataGenerator  and add `ColumnGenerationSpecs` from a YAML file
- `fromFile` wraps both `fromJson` and `fromYaml` into a single API