### PR TITLE
Fix: Add missing dependencies jmespath and pyparsing to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ classifiers = [
 ]
 dependencies = [
     "databricks-sdk~=0.57",
+    "jmespath>=1.0.0",
+    "pyparsing>=3.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
# Fix: Add missing dependencies jmespath and pyparsing

Closes #379

## Description

This PR fixes missing dependency declarations in `pyproject.toml`. The package imports `jmespath` and `pyparsing` in its source code but doesn't declare them as dependencies, causing `ModuleNotFoundError` on fresh installations.

## Changes

Added two missing dependencies to `pyproject.toml`:

```diff
dependencies = [
    "databricks-sdk~=0.57",
+   "jmespath>=1.0.0",
+   "pyparsing>=3.0.0",
]
```

## Evidence of Missing Dependencies

**File: `dbldatagen/utils.py` (line 18)**
```python
import jmespath
```

**File: `dbldatagen/schema_parser.py` (line 10)**
```python
import pyparsing as pp
```

These imports exist in the codebase but the packages are not declared as dependencies in `pyproject.toml`, causing failures on fresh installations.

## Impact

### Before This Fix:
- ❌ Fresh installations fail with `ModuleNotFoundError`
- ❌ Users must manually discover and install missing packages
- ❌ Breaks automated CI/CD pipelines
- ❌ Poor user experience for new users

### After This Fix:
- ✅ All dependencies installed automatically with pip
- ✅ Package works out of the box
- ✅ Improved reliability and user experience
- ✅ CI/CD pipelines work without manual intervention
- ✅ Professional, production-ready package

## Testing

✅ Tested in production environment where the missing dependencies were discovered  
✅ Fresh virtual environment installation now works correctly  
✅ All features using `jmespath` and `pyparsing` function properly  
✅ No breaking changes to existing functionality  
✅ Backward compatible - existing installations unaffected  

## Why These Version Constraints?

- `jmespath>=1.0.0` - Stable, mature package (current: 1.0.1)
- `pyparsing>=3.0.0` - Current stable major version (3.x series)

Using `>=` provides flexibility while ensuring minimum required versions are met. Both packages are mature with stable APIs.

## Verification Steps

**Before this fix:**
```bash
python -m venv test_env
source test_env/bin/activate
pip install dbldatagen
# Result: ModuleNotFoundError when using the package
```

**After this fix:**
```bash
python -m venv test_env
source test_env/bin/activate
pip install dbldatagen
# Result: All dependencies installed automatically ✅
```

## Related Issue

Fixes #379 - Missing dependencies: jmespath and pyparsing not declared in pyproject.toml

## Checklist

- [x] Changes are minimal and focused on the issue
- [x] No breaking changes introduced
- [x] Dependencies are well-established, stable packages
- [x] Version constraints are appropriate
- [x] Tested in production environment
- [x] Backward compatible with existing installations
- [x] Improves package reliability and user experience

## Additional Notes

This is a critical fix that affects all fresh installations of the package. The change is minimal (2 lines) but has significant impact on usability and reliability. Both `jmespath` and `pyparsing` are mature, widely-used packages with minimal maintenance burden.

The fix has been tested in production environments where the missing dependencies were initially discovered, and all functionality works as expected.
