### PR TITLE
[DOCS]: Add template/pattern reference table and examples

### DIFF
--- a/dbldatagen/text_generators.py
+++ b/dbldatagen/text_generators.py
@@ -395,48 +395,74 @@ class TemplateGenerator(TextGenerator, SerializableToDict):  # lgtm [py/missing-
     The base value is passed to the template generation and may be used in the generated text. The base value is the
     value the column would have if the template generation had not been applied.
 
-    It uses the following special chars:
+    It uses the following template tokens:
 
-    ==========  ======================================
-    Chars       Meaning
-    ==========  ======================================
-    ``\\``       Apply escape to next char.
-    v0,v1,..v9  Use base value as an array of values and substitute the `nth` element ( 0 .. 9). Always escaped.
-    x           Insert a random lowercase hex digit
-    X           Insert an uppercase random hex digit
-    d           Insert a random lowercase decimal digit
-    D           Insert an uppercase random decimal digit
-    a           Insert a random lowercase alphabetical character
-    A           Insert a random uppercase alphabetical character
-    k           Insert a random lowercase alphanumeric character
-    K           Insert a random uppercase alphanumeric character
-    n           Insert a random number between 0 .. 255 inclusive. This option must always be escaped
-    N           Insert a random number between 0 .. 65535 inclusive. This option must always be escaped
-    w           Insert a random lowercase word from the ipsum lorem word set. Always escaped
-    W           Insert a random uppercase word from the ipsum lorem word set. Always escaped
-    ==========  ======================================
+    .. list-table:: Template tokens
+       :header-rows: 1
+       :widths: 25 75
 
-    .. note::
-              If escape is used and`escapeSpecialChars` is False, then the following
-              char is assumed to have no special meaning.
-
-              If the `escapeSpecialChars` option is set to True, then the following char only has its special
-              meaning when preceded by an escape.
-
-              Some options must be always escaped for example  ``\\v``, ``\\n`` and ``\\w``.
-
-              A special case exists for ``\\v`` - if immediately followed by a digit 0 - 9, the underlying base value
-              is interpreted as an array of values and the nth element is retrieved where `n` is the digit specified.
+       * - Token
+         - Meaning
+       * - ``a``
+         - Random lowercase letter (``a`` through ``z``).
+       * - ``A``
+         - Random uppercase letter (``A`` through ``Z``).
+       * - ``x``
+         - Random lowercase hex digit (``0`` through ``9`` and ``a`` through ``f``).
+       * - ``X``
+         - Random uppercase hex digit (``0`` through ``9`` and ``A`` through ``F``).
+       * - ``d``
+         - Random decimal digit (``0`` through ``9``).
+       * - ``D``
+         - Random non-zero decimal digit (``1`` through ``9``).
+       * - ``k``
+         - Random lowercase alphanumeric character (``a`` through ``z`` and ``0`` through ``9``).
+       * - ``K``
+         - Random uppercase alphanumeric character (``A`` through ``Z`` and ``0`` through ``9``).
+       * - ``\\n``
+         - Random integer text from ``0`` through ``255`` inclusive; variable width. Always escaped.
+       * - ``\\N``
+         - Random integer text from ``0`` through ``65535`` inclusive; variable width. Always escaped.
+       * - ``\\w``
+         - Random lowercase word from the lowercase ipsum lorem word set, or ``extendedWordList``. Always escaped.
+       * - ``\\W``
+         - Random uppercase word from the uppercase ipsum lorem word set, or uppercased ``extendedWordList``.
+           Always escaped.
+       * - ``\\v``
+         - Entire base value. Always escaped.
+       * - ``\\v0`` through ``\\v9``
+         - Element ``0`` through element ``9`` of an array/list base value. Always escaped.
+       * - ``\\V``
+         - Entire base value. Always escaped.
+       * - ``\\``
+         - Escape the following character. A backslash is always treated as an escape marker and is not emitted
+           as a literal character.
+       * - ``|``
+         - Separate alternatives; one alternative is chosen randomly per generated value. Escape as ``\\|`` for a
+           literal pipe.
 
     In all other cases, the char itself is used.
 
-    The setting of the `escapeSpecialChars` determines how templates generate data.
+    .. note::
+       The default is ``escapeSpecialChars=False`` for backwards compatibility. In this mode, the character classes
+       ``a``, ``A``, ``x``, ``X``, ``d``, ``D``, ``k`` and ``K`` have their special meaning without a leading escape.
+       Escape one of those characters to use it as a literal character.
 
-    If set to False, then the template ``r"\\dr_\\v"`` will generate the values ``"dr_0"`` ... ``"dr_999"`` when applied
-    to the values zero to 999. This conforms to earlier implementations for backwards compatibility.
+       If ``escapeSpecialChars=True``, those character classes only have their special meaning when preceded by an
+       escape. Bare characters are literal.
 
-    If set to True, then the template ``r"dr_\\v"`` will generate the values ``"dr_0"`` ... ``"dr_999"``
-    when applied to the values zero to 999. This conforms to the preferred style going forward
+       Always-escaped classes and base-value substitutions, such as ``\\n``, ``\\w``, ``\\v`` and ``\\V``, require the
+       leading escape in both modes. If ``\\v`` is immediately followed by a digit 0 through 9, the underlying base
+       value is interpreted as an array/list and the indexed element is substituted.
+
+       An unescaped ``|`` separates the template into alternatives; one alternative is chosen at random for each
+       generated value. Escape a pipe as ``\\|`` to include a literal pipe.
+
+    If ``escapeSpecialChars=False``, then the template ``r"\\dr_\\v"`` will generate the values ``"dr_0"`` ...
+    ``"dr_999"`` when applied to the values zero to 999.
+
+    If ``escapeSpecialChars=True``, then the template ``r"dr_\\v"`` will generate the values ``"dr_0"`` ...
+    ``"dr_999"`` when applied to the values zero to 999.
     """
 
     _template: str

--- a/dbldatagen/text_generators.py
+++ b/dbldatagen/text_generators.py
@@ -420,18 +420,21 @@ class TemplateGenerator(TextGenerator, SerializableToDict):  # lgtm [py/missing-
        * - ``K``
          - Random uppercase alphanumeric character (``A`` through ``Z`` and ``0`` through ``9``).
        * - ``\\n``
-         - Random integer text from ``0`` through ``255`` inclusive; variable width. Always escaped.
+         - Random integer text from ``0`` through ``255`` inclusive; variable width.
+            Must always be escaped with ``\\``.
        * - ``\\N``
-         - Random integer text from ``0`` through ``65535`` inclusive; variable width. Always escaped.
+         - Random integer text from ``0`` through ``65535`` inclusive; variable width.
+            Must always be escaped with ``\\``.
        * - ``\\w``
-         - Random lowercase word from the lowercase ipsum lorem word set, or ``extendedWordList``. Always escaped.
+         - Random lowercase word from the lowercase ipsum lorem word set, or ``extendedWordList``.
+            Must always be escaped with ``\\``.
        * - ``\\W``
          - Random uppercase word from the uppercase ipsum lorem word set, or uppercased ``extendedWordList``.
-           Always escaped.
+            Must always be escaped with ``\\``.
        * - ``\\v``
-         - Entire base value. Always escaped.
+         - Entire base value. Must always be escaped with ``\\``.
        * - ``\\v0`` through ``\\v9``
-         - Element ``0`` through element ``9`` of an array/list base value. Always escaped.
+         - Element ``0`` through element ``9`` of an array/list base value. Must always be escaped with ``\\``.
        * - ``\\V``
          - Entire base value. Must always be escaped with ``\\``.
        * - ``\\``

--- a/dbldatagen/text_generators.py
+++ b/dbldatagen/text_generators.py
@@ -433,7 +433,7 @@ class TemplateGenerator(TextGenerator, SerializableToDict):  # lgtm [py/missing-
        * - ``\\v0`` through ``\\v9``
          - Element ``0`` through element ``9`` of an array/list base value. Always escaped.
        * - ``\\V``
-         - Entire base value. Always escaped.
+         - Entire base value. Must always be escaped with ``\\``.
        * - ``\\``
          - Escape the following character. A backslash is always treated as an escape marker and is not emitted
            as a literal character.

--- a/docs/source/textdata.rst
+++ b/docs/source/textdata.rst
@@ -136,62 +136,163 @@ VINs, IBANs and many other structured codes.
 The base value is passed to the template generation and may be used in the generated text. The base value is the
 value the column would have if the template generation had not been applied.
 
-It uses the following special chars:
+It uses the following template tokens:
 
-    ========  ======================================
-    Chars     Meaning
-    ========  ======================================
-    ``\``     Apply escape to next char.
-    v0,..v9   Use base value as an array of values and substitute the `nth` element ( 0 .. 9). Always escaped.
-    x         Insert a random lowercase hex digit
-    X         Insert an uppercase random hex digit
-    d         Insert a random lowercase decimal digit
-    D         Insert an uppercase random decimal digit
-    a         Insert a random lowercase alphabetical character
-    A         Insert a random uppercase alphabetical character
-    k         Insert a random lowercase alphanumeric character
-    K         Insert a random uppercase alphanumeric character
-    n         Insert a random number between 0 .. 255 inclusive. This option must always be escaped
-    N         Insert a random number between 0 .. 65535 inclusive. This option must always be escaped
-    w         Insert a random lowercase word from the ipsum lorem word set. Always escaped
-    W         Insert a random uppercase word from the ipsum lorem word set. Always escaped
-    ========  ======================================
+.. list-table:: Template meta-character reference
+   :header-rows: 1
+   :widths: 18 18 32 26 18
+
+   * - Group
+     - Token
+     - Inserts or behavior
+     - Range or set
+     - Always escaped?
+   * - Character classes
+     - ``a``
+     - Random lowercase letter
+     - ``a`` through ``z``
+     - No; mode-dependent
+   * - Character classes
+     - ``A``
+     - Random uppercase letter
+     - ``A`` through ``Z``
+     - No; mode-dependent
+   * - Character classes
+     - ``x``
+     - Random lowercase hex digit
+     - ``0`` through ``9`` and ``a`` through ``f``
+     - No; mode-dependent
+   * - Character classes
+     - ``X``
+     - Random uppercase hex digit
+     - ``0`` through ``9`` and ``A`` through ``F``
+     - No; mode-dependent
+   * - Character classes
+     - ``d``
+     - Random decimal digit
+     - ``0`` through ``9``
+     - No; mode-dependent
+   * - Character classes
+     - ``D``
+     - Random non-zero decimal digit
+     - ``1`` through ``9``
+     - No; mode-dependent
+   * - Character classes
+     - ``k``
+     - Random lowercase alphanumeric character
+     - ``a`` through ``z`` and ``0`` through ``9``
+     - No; mode-dependent
+   * - Character classes
+     - ``K``
+     - Random uppercase alphanumeric character
+     - ``A`` through ``Z`` and ``0`` through ``9``
+     - No; mode-dependent
+   * - Always-escaped classes
+     - ``\n``
+     - Random integer text
+     - ``0`` through ``255`` inclusive; variable width
+     - Yes
+   * - Always-escaped classes
+     - ``\N``
+     - Random integer text
+     - ``0`` through ``65535`` inclusive; variable width
+     - Yes
+   * - Always-escaped classes
+     - ``\w``
+     - Random lowercase word
+     - Lowercase ipsum lorem word set, or ``extendedWordList``
+     - Yes
+   * - Always-escaped classes
+     - ``\W``
+     - Random uppercase word
+     - Uppercase ipsum lorem word set, or uppercased ``extendedWordList``
+     - Yes
+   * - Base-value substitution
+     - ``\v``
+     - Entire base value
+     - Value the column would otherwise have had
+     - Yes
+   * - Base-value substitution
+     - ``\v0`` through ``\v9``
+     - Base-value element by index
+     - Element ``0`` through element ``9`` of an array/list base value
+     - Yes
+   * - Base-value substitution
+     - ``\V``
+     - Entire base value
+     - Value the column would otherwise have had
+     - Yes
+   * - Escape
+     - ``\``
+     - Escapes the following character (see escaping rules below). A backslash is always treated as an
+       escape marker and is not emitted as a literal character.
+     - See escaping rules below
+     - N/A
+   * - Alternation
+     - ``|``
+     - Chooses one template alternative at random per generated value
+     - Split on each unescaped ``|``; use ``\|`` for a literal pipe
+     - No
 
 In all other cases, the char itself is used.
 
-The setting of the ``escapeSpecialChars`` determines how the template generate interprets the special chars.
+Escaping and the escapeSpecialChars option
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If set to False, which defaults to `False`, then the special char does not need to be escaped to have its special
-meaning. But the special char must be escaped to be treated as a literal char.
+The setting of ``escapeSpecialChars`` determines how the template generator interprets the character classes
+``a``, ``A``, ``x``, ``X``, ``d``, ``D``, ``k`` and ``K``.
 
-So the template ``r"\dr_\v"`` will generate the values ``"dr_0"`` ... ``"dr_999"`` when used via the template option
-and applied to the values zero to 999.
-Here the the character `d` is escaped to avoid interpretation as a special character.
+The default is ``escapeSpecialChars=False`` for backwards compatibility. In this mode, those character classes have
+their special meaning without a leading escape. Escape one of those characters to use it as a literal character.
+Always-escaped classes and base-value substitutions, such as ``\n``, ``\w``, ``\v`` and ``\V``, still require the
+leading escape.
 
-If set to True, then the special char only has its special meaning when preceded by an escape.
+For example, the template ``r"\dr_\v"`` generates the values ``"dr_0"`` ... ``"dr_999"`` when used via the
+``template=`` option and applied to the values zero to 999. Here ``\d`` is an escaped literal ``d``, ``r_`` is
+literal text, and ``\v`` substitutes the base value.
 
-So the option `text=dg.TemplateGenerator(r'dr_\v', escapeSpecialChars=True)` will generate the values
-``"dr_0"`` ... ``"dr_999"`` when applied to the values zero to 999.
+If ``escapeSpecialChars=True``, those character classes only have their special meaning when preceded by an escape.
+Bare characters are literal. For example, ``text=dg.TemplateGenerator(r"dr_\v", escapeSpecialChars=True)`` generates
+the values ``"dr_0"`` ... ``"dr_999"`` when applied to the values zero to 999.
 
-This conforms to earlier implementations for backwards compatibility.
+Alternation
+^^^^^^^^^^^
 
-.. note::
-          Setting the argument `escapeSpecialChars=False` means that the special char does not need to be escaped to
-          be treated as a special char. But it must be escaped to be treated as a literal char.
+An unescaped ``|`` separates the template into alternatives. One alternative is selected at random for each generated
+value. Escape a pipe as ``\|`` to include a literal pipe in the generated text.
 
-          If the ``escapeSpecialChars`` option is set to True, then the following char only has its special
-          meaning when preceded by an escape.
+For example, ``(ddd)-ddd-dddd|1(ddd) ddd-dddd|ddd ddddddd`` generates one of three phone-number shapes. The
+parentheses in this template are literal output characters. Similarly, ``\w.\w@\w.com|\w@\w.co.u\k`` generates an
+email-like value using one of two domain shapes.
 
-          Some options must be always escaped for example  ``\\v``, ``\\n`` and ``\\w``.
+Worked examples
+^^^^^^^^^^^^^^^
 
-          A special case exists for ``\\v`` - if immediately followed by a digit 0 - 9, the underlying base value
-          is interpreted as an array of values and the nth element is retrieved where `n` is the digit specified.
+The template syntax does not include repetition operators or optional groups. Repeat a class character literally for
+fixed-width output, such as ``dddd`` for four random decimal digits.
 
-          The ``escapeSpecialChars`` is set to False by default for backwards compatibility.
+.. list-table:: Template examples
+   :header-rows: 1
+   :widths: 35 65
 
-          To use the ``escapeSpecialChars`` option, use the variant
-          ``text=dg.TemplateGenerator(template=..., escapeSpecialChars=True)``
-
+   * - Template
+     - Generates
+   * - ``\n.\n.\n.\n``
+     - A dotted IPv4-style address; each octet is a random integer from ``0`` through ``255``.
+   * - ``ddd-dd-dddd``
+     - A US-SSN-shaped value with decimal digits from ``0`` through ``9``.
+   * - ``XXXX-XXXX-XXXX-XXXX``
+     - Four groups of uppercase hexadecimal digits separated by hyphens.
+   * - ``\w.\w@\w.com|\w@\w.co.u\k``
+     - An email-like value in one of two shapes, with words from the configured word list.
+   * - ``(ddd)-ddd-dddd|1(ddd) ddd-dddd|ddd ddddddd``
+     - A phone-number-shaped value in one of three formats; parentheses are literal characters.
+   * - ``r"\dr_\v"`` with default ``escapeSpecialChars=False``
+     - ``dr_`` followed by the base value; ``\d`` is a literal ``d`` in default mode.
+   * - ``r"dr_\v"`` with ``escapeSpecialChars=True``
+     - ``dr_`` followed by the base value; bare ``d`` and ``r`` are literal characters.
+   * - ``\v0-\v1``
+     - Elements ``0`` and ``1`` of an array/list base value joined by a hyphen.
 
 Using a custom word list
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -256,4 +357,3 @@ generated data with other data sources to generate the required data.
 
 In these cases, the generator can be specified to produce lookup keys that can be used to join with the
 other data sources.
-

--- a/docs/source/textdata.rst
+++ b/docs/source/textdata.rst
@@ -239,11 +239,11 @@ In all other cases, the char itself is used.
 Escaping and the escapeSpecialChars option
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The setting of ``escapeSpecialChars`` determines how the template generator interprets the character classes
-``a``, ``A``, ``x``, ``X``, ``d``, ``D``, ``k`` and ``K``.
+The ``escapeSpecialChars`` parameter determines how the template generator interprets reserved character classes
+(e.g. ``a``, ``A``, ``x``, ``X``, ``d``, ``D``, ``k`` and ``K``).
 
-The default is ``escapeSpecialChars=False`` for backwards compatibility. In this mode, those character classes have
-their special meaning without a leading escape. Escape one of those characters to use it as a literal character.
+The default is ``escapeSpecialChars=False`` for backwards compatibility. In this mode, reserved character classes have
+their special meaning without a leading escape. Escape one of these reserved characters to use it as a literal character.
 Always-escaped classes and base-value substitutions, such as ``\n``, ``\w``, ``\v`` and ``\V``, still require the
 leading escape.
 
@@ -251,7 +251,7 @@ For example, the template ``r"\dr_\v"`` generates the values ``"dr_0"`` ... ``"d
 ``template=`` option and applied to the values zero to 999. Here ``\d`` is an escaped literal ``d``, ``r_`` is
 literal text, and ``\v`` substitutes the base value.
 
-If ``escapeSpecialChars=True``, those character classes only have their special meaning when preceded by an escape.
+If ``escapeSpecialChars=True``, reserved character classes only have their special meaning when preceded by an escape.
 Bare characters are literal. For example, ``text=dg.TemplateGenerator(r"dr_\v", escapeSpecialChars=True)`` generates
 the values ``"dr_0"`` ... ``"dr_999"`` when applied to the values zero to 999.
 


### PR DESCRIPTION
## Changes

The string template / pattern mini-language behind the `template=` option and the `TemplateGenerator` class is easy to get wrong because its grammar was only partially documented, and the reference table that did exist was both incomplete and inaccurate. This PR completes and corrects that documentation so a reader can write a template correctly without reading the source.

In `docs/source/textdata.rst` the partial special-character table is replaced with a complete meta-character reference, grouped so the reader can see how the pieces relate: the unescaped character classes, the always-escaped classes (`\n`, `\N`, `\w`, `\W`), base-value substitution (`\v`, `\v0`..`\v9`, `\V`), the escape character, and alternation with `|`. The most consequential correction is to the `d` and `D` rows, which the old table presented as a lowercase/uppercase pair: in reality `d` inserts any decimal digit `0-9` while `D` inserts a non-zero digit `1-9`, so a reader relying on the old wording would have been surprised by the absence of zeros. The escape row no longer claims that a doubled backslash yields a literal backslash, since the generator treats every backslash as an escape marker rather than emitting one.

The page also gains three short subsections. "Escaping and the escapeSpecialChars option" explains why the default (`False`) and opt-in (`True`) modes interpret the same characters differently, using the existing `\dr_\v` and `dr_\v` examples. "Alternation" explains that `|` chooses one alternative at random per generated value and that parentheses in a template are literal output. "Worked examples" maps real, parser-accepted templates (a dotted IPv4 address, an SSN shape, a card-like grouping, an email, a phone number, and base-value joins) to plain descriptions of what they produce, and notes that the grammar has no repetition operator or optional groups, so fixed-width output comes from repeating a class character.

So that the documentation does not drift, the `TemplateGenerator` class docstring in `dbldatagen/text_generators.py` receives the same corrections and stays the single source of truth. No parsing, generation, mappings, or behavior are changed; this is documentation only.

This is the documentation half of the referenced issue. The broader grammar/parser redesign, separating parsing from generation, and a migration path are intentionally left out, as they are a larger multi-subsystem change.

### Linked issues

Refs #450

<!-- Partial scope: this PR delivers only the documentation reference-table-and-examples deliverable of #450; the parser/grammar redesign is out of scope, so the issue is referenced rather than closed. -->

### Requirements

- [x] manually tested
- [x] updated documentation
- [ ] updated demos (n/a, documentation-only change)
- [ ] updated tests (n/a, documentation-only change)

Documentation-only change. `python -m py_compile dbldatagen/text_generators.py` passes, and both the rST page and the rendered class docstring parse under docutils with no new warnings on the edited tables. Every meta-character description was cross-checked against the implementation (`_templateMappings`, `_templateEscapedMappings`, `_splitTemplates`, `_prepareTemplateStrings`, `_applyTemplateStringsForTemplate`).

I understand databrickslabs projects require signing the Databricks CLA before merge, and I am happy to complete that.
