### PR TITLE
feat: add Pareto (power-law) distribution

### DIFF
--- a/dbldatagen/distributions/__init__.py
+++ b/dbldatagen/distributions/__init__.py
@@ -23,5 +23,6 @@ from .data_distribution import DataDistribution
 from .beta import Beta
 from .gamma import Gamma
 from .exponential_distribution import Exponential
+from .pareto import Pareto
 
-__all__ = ["normal_distribution", "gamma", "beta", "data_distribution", "exponential_distribution"]
+__all__ = ["normal_distribution", "gamma", "beta", "data_distribution", "exponential_distribution", "pareto"]

--- a/dbldatagen/distributions/exponential_distribution.py
+++ b/dbldatagen/distributions/exponential_distribution.py
@@ -69,10 +69,11 @@ class Exponential(DataDistribution):
         amin = np.amin(results) * 1.0
         amax = np.amax(results) * 1.0
 
+        if amin == amax:
+            return pd.Series(np.zeros_like(results))
+
         adjusted_results = results - amin
-
         scaling_factor = amax - amin
-
         results2 = adjusted_results / scaling_factor
 
         return pd.Series(results2)

--- a/dbldatagen/distributions/gamma.py
+++ b/dbldatagen/distributions/gamma.py
@@ -90,11 +90,13 @@ class Gamma(DataDistribution):
         amin = np.amin(results) * 1.0
         amax = np.amax(results) * 1.0
 
+        if amin == amax:
+            return pd.Series(np.zeros_like(results))
+
         adjusted_results = results - amin
-
         scaling_factor = amax - amin
-
         results2 = adjusted_results / scaling_factor
+
         return pd.Series(results2)
 
     def generateNormalizedDistributionSample(self) -> Column:

--- a/dbldatagen/distributions/normal_distribution.py
+++ b/dbldatagen/distributions/normal_distribution.py
@@ -66,11 +66,13 @@ class Normal(DataDistribution):
         amin = np.amin(results) * 1.0
         amax = np.amax(results) * 1.0
 
+        if amin == amax:
+            return pd.Series(np.zeros_like(results))
+
         adjusted_results = results - amin
-
         scaling_factor = amax - amin
-
         results2 = adjusted_results / scaling_factor
+
         return pd.Series(results2)
 
     def generateNormalizedDistributionSample(self) -> Column:

--- a/dbldatagen/distributions/pareto.py
+++ b/dbldatagen/distributions/pareto.py
@@ -1,0 +1,107 @@
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+This file defines the Pareto statistical distributions related classes
+
+"""
+
+import numpy as np
+import pandas as pd
+import pyspark.sql.functions as F
+from pyspark.sql import Column
+from pyspark.sql.types import FloatType
+
+from dbldatagen.datagen_types import NumericLike
+from dbldatagen.distributions.data_distribution import DataDistribution, register_distribution
+from dbldatagen.serialization import SerializableToDict
+
+
+@register_distribution("pareto", shape=1.0)
+class Pareto(DataDistribution):
+    """Specifies that random samples should be drawn from the Pareto (power-law) distribution parameterized
+    by shape. See https://en.wikipedia.org/wiki/Pareto_distribution.
+
+    The Pareto distribution produces a heavy right tail: most generated values are small while a small
+    number of values are very large. This makes it suitable for modelling naturally skewed quantities such
+    as the number of orders per customer, file sizes, or city populations.
+
+    The shape parameter (also called the tail index, `alpha`) controls how skewed the distribution is.
+    A smaller shape produces a heavier tail (more skew); a larger shape produces a lighter tail (less skew).
+    A shape of approximately 1.16 corresponds to the classic 80/20 Pareto principle.
+
+    :param shape: Shape parameter (tail index `alpha`); Should be a float, int or other numeric value greater than 0
+    """
+
+    def __init__(self, shape: NumericLike | None = None) -> None:
+        DataDistribution.__init__(self)
+        self._shape = shape if shape is not None else 1.0
+
+    def _toInitializationDict(self) -> dict[str, object]:
+        """Converts an object to a Python dictionary. Keys represent the object's
+        constructor arguments.
+
+        :return: Dictionary representation of the object
+        """
+        _options = {"kind": self.__class__.__name__, "shape": self._shape}
+        return {
+            k: v._toInitializationDict() if isinstance(v, SerializableToDict) else v
+            for k, v in _options.items()
+            if v is not None
+        }
+
+    @property
+    def shape(self) -> NumericLike | None:
+        """Returns the shape parameter.
+
+        :return: Shape parameter
+        """
+        return self._shape
+
+    def __str__(self) -> str:
+        """Returns a string representation of the object.
+
+        :return: String representation of the object
+        """
+        return f"ParetoDistribution(shape(`alpha`)={self._shape}, seed={self.randomSeed})"
+
+    @staticmethod
+    def pareto_func(shape_series: pd.Series, random_seed: pd.Series) -> pd.Series:
+        """Generates samples from the Pareto distribution using pandas / numpy.
+
+        :param shape_series: Value for shape parameter as Pandas Series
+        :param random_seed: Value for randomSeed parameter as Pandas Series
+
+        :return: Random samples from distribution scaled to values between 0 and 1
+        """
+        shape = shape_series.to_numpy()
+        random_seed = random_seed.to_numpy()[0]
+
+        rng = DataDistribution.get_np_random_generator(random_seed)
+
+        results = rng.pareto(shape)
+
+        # scale results to range [0, 1]
+        amin = np.amin(results) * 1.0
+        amax = np.amax(results) * 1.0
+
+        adjusted_results = results - amin
+
+        scaling_factor = amax - amin
+
+        results2 = adjusted_results / scaling_factor
+        return pd.Series(results2)
+
+    def generateNormalizedDistributionSample(self) -> Column:
+        """Generates a sample of data for the distribution.
+
+        :return: Pyspark SQL column expression for the sample values
+        """
+        pareto_sample = F.pandas_udf(self.pareto_func, returnType=FloatType()).asNondeterministic()  # type: ignore
+
+        newDef: Column = pareto_sample(
+            F.lit(self._shape),
+            F.lit(self.randomSeed) if self.randomSeed is not None else F.lit(-1.0),
+        )
+        return newDef

--- a/dbldatagen/distributions/pareto.py
+++ b/dbldatagen/distributions/pareto.py
@@ -86,11 +86,13 @@ class Pareto(DataDistribution):
         amin = np.amin(results) * 1.0
         amax = np.amax(results) * 1.0
 
+        if amin == amax:
+            return pd.Series(np.zeros_like(results))
+
         adjusted_results = results - amin
-
         scaling_factor = amax - amin
-
         results2 = adjusted_results / scaling_factor
+
         return pd.Series(results2)
 
     def generateNormalizedDistributionSample(self) -> Column:

--- a/docs/source/DISTRIBUTIONS.md
+++ b/docs/source/DISTRIBUTIONS.md
@@ -20,6 +20,7 @@ The following distributions are supported:
 - Beta distribution
 - Gamma distribution
 - Exponential distribution
+- Pareto distribution
 
 > Note the `distribution` option will have no effect for values that are not randomly generated as
 > per use of the `random` option.
@@ -128,8 +129,41 @@ constructor parameters.
 
 .withColumn("w", "float", minValue=0, maxValue=100, random=True,
             distribution="exponential(rate=1.5)")
+
+.withColumn("v", "float", minValue=0, maxValue=100, random=True,
+            distribution="pareto(shape=1.16)")
 ```
 
 Note that partial overrides are supported. Any arguments you omit fall back to their default 
 values. For example, `"gamma(shape=2.0)"` will create a distribution with the default value 
 `scale=1.0`.
+
+## Pareto distribution
+
+The Pareto (power-law) distribution is useful for modelling naturally skewed quantities where
+most values are small but a small number of values are very large — for example, the number of
+orders per customer, file sizes, or city populations.
+
+The `shape` parameter (tail index `alpha`) controls how heavy the tail is. A smaller value
+produces more skew; `shape ≈ 1.16` corresponds to the classic 80/20 Pareto principle.
+
+```python
+import dbldatagen as dg
+import dbldatagen.distributions as dist
+
+testDataSpec = (
+    dg.DataGenerator(spark, name="pareto_example", rows=100_000)
+    .withColumn("customer_id", "integer", minValue=1, maxValue=100_000)
+    # most customers place few orders; a handful place very many
+    .withColumn(
+        "order_count",
+        "integer",
+        minValue=1,
+        maxValue=500,
+        random=True,
+        distribution=dist.Pareto(shape=1.16),
+    )
+)
+
+dfTestData = testDataSpec.build()
+```

--- a/docs/source/DISTRIBUTIONS.md
+++ b/docs/source/DISTRIBUTIONS.md
@@ -13,10 +13,11 @@ When the field is not numeric, the underlying seed value will generated to confo
 known distribution before being converted 
 to the appropriate type as per usual semantics. 
 
-Note that the distribution will be scaled to the possible range of values
+Note that the distribution will be scaled to the possible range of values. If all samples from a
+distribution are equal (e.g. if the requested data contains only 1 row), the minimum value is returned.
 
 The following distributions are supported:
-- normal or Gaussian distribution
+- Normal (Gaussian) distribution
 - Beta distribution
 - Gamma distribution
 - Exponential distribution

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -560,7 +560,7 @@ class TestDistributions:
 
     def test_distribution_string_invalid_lists_valid_options(self):
         """Test that the error message for an invalid distribution lists valid options."""
-        with pytest.raises(ValueError, match="Valid distribution names are: beta, exponential, gamma, normal"):
+        with pytest.raises(ValueError, match="Valid distribution names are: beta, exponential, gamma, normal, pareto"):
             dg.DataGenerator(
                 sparkSession=spark, name="test_invalid2", rows=100, seedMethod='hash_fieldname'
             ).withIdOutput().withColumn(
@@ -643,7 +643,7 @@ class TestDistributions:
 
     def test_registered_names(self):
         """Test that registeredNames returns a sorted list of all registered names."""
-        assert dist.DataDistribution.registeredNames() == ["beta", "exponential", "gamma", "normal"]
+        assert dist.DataDistribution.registeredNames() == ["beta", "exponential", "gamma", "normal", "pareto"]
 
     def test_distribution_string_missing_equals_raises(self):
         """Test that a bare token with no '=' inside the argument list raises ValueError."""
@@ -656,3 +656,97 @@ class TestDistributions:
         assert isinstance(n, dist.Normal)
         assert n.mean == 0.0
         assert n.stddev == 1.0
+
+    def test_pareto_distribution(self):
+        pareto_data_generator = (
+            dg.DataGenerator(sparkSession=spark, rows=self.TESTDATA_ROWS, partitions=4)
+            .withIdOutput()
+            .withColumn("code1", "integer", minValue=1, maxValue=20, step=1)
+            .withColumn("code4", "integer", minValue=1, maxValue=40, step=1, random=True, distribution=dist.Pareto(1.0))
+            .withColumn(
+                "sector_status_desc",
+                "string",
+                minValue=1,
+                maxValue=200,
+                step=1,
+                prefix='status',
+                random=True,
+                distribution="normal",
+            )
+            .withColumn(
+                "tech", "string", values=["GSM", "LTE", "UMTS", "UNKNOWN"], weights=desired_weights, random=True
+            )
+        )
+        df_pareto_data = pareto_data_generator.build().cache()
+
+        df_summary = df_pareto_data.agg(
+            F.min('code4').alias('min_c4'),
+            F.max('code4').alias('max_c4'),
+            F.avg('code4').alias('mean_c4'),
+        )
+        df_summary.show()
+
+        summary_data = df_summary.collect()[0]
+
+        assert summary_data['min_c4'] == 1
+        assert summary_data['max_c4'] == 40
+
+    def test_pareto_generation_func(self):
+        dist_instance = dist.Pareto(1.0)
+
+        data_size = 10000
+        shapes = pd.Series(np.full(data_size, dist_instance.shape))
+        seeds = pd.Series(np.full(data_size, 42, dtype=np.int32))
+        results = dist_instance.pareto_func(shapes, seeds)
+
+        assert len(results) == len(shapes)
+
+        # output must be normalized to [0, 1]
+        assert float(results.min()) >= 0.0
+        assert float(results.max()) <= 1.0
+
+        # Pareto is right-skewed: mean sits well below 0.5
+        m1 = float(np.mean(results))
+        s1 = float(np.std(results))
+        assert m1 < 0.5
+        assert s1 == pytest.approx(0.013, abs=0.003)
+
+        # unseeded run has the same statistical shape
+        seeds2 = pd.Series(np.full(data_size, -1, dtype=np.int32))
+        results2 = dist_instance.pareto_func(shapes, seeds2)
+        assert float(results2.min()) >= 0.0
+        assert float(results2.max()) <= 1.0
+        assert float(np.mean(results2)) < 0.5
+
+    def test_pareto_distribution_string(self):
+        """Test that 'pareto' string resolves to a Pareto distribution."""
+        data_generator = (
+            dg.DataGenerator(sparkSession=spark, name="test_pareto_str", rows=100, seedMethod='hash_fieldname')
+            .withIdOutput()
+            .withColumn("code1", "integer", minValue=1, maxValue=20, step=1, random=True, distribution="pareto")
+        )
+        df = data_generator.build()
+        assert df.count() == 100
+
+    def test_pareto_distribution_string_with_kwargs(self):
+        """Test that pareto(shape=…) overrides the default shape."""
+        p = dist.DataDistribution.fromName("pareto(shape=2.0)")
+        assert isinstance(p, dist.Pareto)
+        assert p.shape == 2.0
+
+    def test_pareto_shape_property(self):
+        """Test that the shape property round-trips correctly."""
+        p = dist.Pareto(shape=3.5)
+        assert p.shape == 3.5
+
+    def test_pareto_default_shape(self):
+        """Test that omitting shape gives the registered default of 1.0."""
+        p = dist.Pareto()
+        assert p.shape == 1.0
+
+    def test_pareto_str_representation(self):
+        """Test __str__ includes the key parameters."""
+        p = dist.Pareto(shape=1.5).withRandomSeed(7)
+        s = str(p)
+        assert "1.5" in s
+        assert "7" in s

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -750,3 +750,69 @@ class TestDistributions:
         s = str(p)
         assert "1.5" in s
         assert "7" in s
+
+    def test_pareto_generation_func_single_row_batch(self):
+        """A single-row batch normalizes to 0.0 rather than dividing 0/0 into NaN."""
+        dist_instance = dist.Pareto(1.0)
+        shapes = pd.Series(np.full(1, dist_instance.shape))
+        seeds = pd.Series(np.full(1, 42, dtype=np.int32))
+
+        results = dist_instance.pareto_func(shapes, seeds)
+
+        assert (results.to_numpy() == 0.0).all()
+
+    def test_exponential_generation_func_single_row_batch(self):
+        """A single-row batch normalizes to 0.0 rather than dividing 0/0 into NaN."""
+        dist_instance = dist.Exponential(0.5)
+        scales = pd.Series(np.full(1, dist_instance.scale))
+        seeds = pd.Series(np.full(1, 42, dtype=np.int32))
+
+        results = dist_instance.exponential_func(scales, seeds)
+
+        assert (results.to_numpy() == 0.0).all()
+
+    def test_gamma_generation_func_single_row_batch(self):
+        """A single-row batch normalizes to 0.0 rather than dividing 0/0 into NaN."""
+        dist_instance = dist.Gamma(0.5, 0.5)
+        shapes = pd.Series(np.full(1, dist_instance.shape))
+        scales = pd.Series(np.full(1, dist_instance.scale))
+        seeds = pd.Series(np.full(1, 42, dtype=np.int32))
+
+        results = dist_instance.gamma_func(shapes, scales, seeds)
+
+        assert (results.to_numpy() == 0.0).all()
+
+    def test_normal_generation_func_single_row_batch(self):
+        """A single-row batch normalizes to 0.0 rather than dividing 0/0 into NaN."""
+        dist_instance = dist.Normal(20.0, 1.0)
+        means = pd.Series(np.full(1, 100.0))
+        std_deviations = pd.Series(np.full(1, 20.0))
+        seeds = pd.Series(np.full(1, 42, dtype=np.int32))
+
+        results = dist_instance.normal_func(means, std_deviations, seeds)
+
+        assert (results.to_numpy() == 0.0).all()
+
+    @pytest.mark.parametrize(
+        "distribution",
+        [
+            dist.Pareto(1.0),
+            dist.Exponential(0.5),
+            dist.Gamma(0.5, 0.5),
+            dist.Normal(20.0, 1.0),
+        ],
+        ids=["pareto", "exponential", "gamma", "normal"],
+    )
+    def test_single_row_partitions_yield_min_value(self, distribution):
+        """End-to-end: more partitions than rows forces single-row batches. Each normalizes to
+        0.0, so every generated value collapses to exactly minValue instead of becoming NaN."""
+        min_value = 5.0
+        data_generator = (
+            dg.DataGenerator(sparkSession=spark, rows=4, partitions=8, seed=42)
+            .withIdOutput()
+            .withColumn("value", "float", minValue=min_value, maxValue=100.0, random=True, distribution=distribution)
+        )
+        rows = data_generator.build().collect()
+
+        for row in rows:
+            assert row["value"] == min_value


### PR DESCRIPTION
## Changes

Adds a `Pareto` distribution class to `dbldatagen.distributions`, implementing the
Pareto (power-law) distribution for generating right-skewed synthetic data.

- `dbldatagen/distributions/pareto.py` — new `Pareto(shape)` class backed by
  `numpy.random.Generator.pareto`, with output min-max normalised to [0, 1]
- `dbldatagen/distributions/__init__.py` — exports `Pareto`
- `tests/test_distributions.py` — 7 new tests covering construction, shape
  property, string resolution, kwarg override, `pareto_func` statistical
  properties, and end-to-end DataGenerator integration; 2 existing
  registered-name assertions updated to include `"pareto"`
- `docs/source/DISTRIBUTIONS.md` — adds Pareto to the supported-distributions
  list, string-spec example, and a usage section with code sample

The distribution is accessible as an object (`dist.Pareto(shape=1.16)`) or as a
string (`distribution="pareto"` / `distribution="pareto(shape=1.16)"`), consistent
with the existing Normal, Beta, Gamma, and Exponential registrations.

### Linked issues

Closes #463

### Requirements

- [x] manually tested
- [x] updated documentation
- [ ] updated demos
- [x] updated tests

`make fmt` passes (black, ruff, mypy, pylint 10.00/10).
`make test` passes: 642 passed, 1 pre-existing skip, overall coverage 94%.