### PR TITLE
Fix integral type bounds checking for numeric data ranges

### DIFF
--- a/dbldatagen/nrange.py
+++ b/dbldatagen/nrange.py
@@ -26,6 +26,15 @@ from .serialization import SerializableToDict
 _OLD_MIN_OPTION = "min"
 _OLD_MAX_OPTION = "max"
 
+#: inclusive `(minValue, maxValue)` limits of each Spark SQL integral type. These are value limits, so they
+#: are narrower than the count of distinct values checked by `_MAX_TYPE_RANGE` in `column_spec_options`.
+_INTEGRAL_TYPE_BOUNDS: dict[type, tuple[int, int]] = {
+    ByteType: (-(2**7), 2**7 - 1),
+    ShortType: (-(2**15), 2**15 - 1),
+    IntegerType: (-(2**31), 2**31 - 1),
+    LongType: (-(2**63), 2**63 - 1),
+}
+
 
 class NRange(DataRange):
     """Represents a numeric interval for data generation.
@@ -159,12 +168,13 @@ class NRange(DataRange):
 
         - Populate `minValue` and `maxValue` to the default range for the data type
           if they are not already set.
-        - Validate that `maxValue` is within the allowed range for `ByteType` and
-          `ShortType`.
+        - Validate that `minValue` and `maxValue` are within the representable range of the
+          integral types (`ByteType`, `ShortType`, `IntegerType` and `LongType`).
         - Set a default `step` of 1.0 for floating point types and 1 for integral types
           if `step` is not already set.
 
         :param ctype: Spark SQL data type for the column.
+        :raises ValueError: If `minValue` or `maxValue` is outside the range of an integral `ctype`.
         """
         numeric_types = (DecimalType, FloatType, DoubleType, ByteType, ShortType, IntegerType, LongType)
 
@@ -176,13 +186,26 @@ class NRange(DataRange):
                 if self.maxValue is None:
                     self.maxValue = numeric_range[1]
 
-        if isinstance(ctype, ShortType) and self.maxValue is not None:
-            if self.maxValue > 65536:
-                raise ValueError("`maxValue` must be within the valid range for ShortType.")
+        integral_bounds = _INTEGRAL_TYPE_BOUNDS.get(type(ctype))
+        if integral_bounds is not None:
+            type_min, type_max = integral_bounds
+            type_name = type(ctype).__name__
 
-        if isinstance(ctype, ByteType) and self.maxValue is not None:
-            if self.maxValue > 256:
-                raise ValueError("`maxValue` must be within the valid range (0 - 256) for ByteType.")
+            # each bound is checked against both limits, as a decreasing range puts the larger value in
+            # `minValue` and the smaller one in `maxValue`
+            for bound_name, bound_value in (("minValue", self.minValue), ("maxValue", self.maxValue)):
+                if bound_value is None:
+                    continue
+
+                if bound_value < type_min:
+                    raise ValueError(
+                        f"`{bound_name}` of {bound_value} is below the minimum value of {type_min} for {type_name}."
+                    )
+
+                if bound_value > type_max:
+                    raise ValueError(
+                        f"`{bound_name}` of {bound_value} is above the maximum value of {type_max} for {type_name}."
+                    )
 
         if isinstance(ctype, (DoubleType, FloatType)) and self.step is None:
             self.step = 1.0

--- a/dbldatagen/nrange.py
+++ b/dbldatagen/nrange.py
@@ -187,26 +187,29 @@ class NRange(DataRange):
                     self.maxValue = numeric_range[1]
 
         integral_bounds = _INTEGRAL_TYPE_BOUNDS.get(type(ctype))
-        if integral_bounds is not None:
+        # both bounds are already populated from the type defaults above, so this only narrows the type
+        if integral_bounds is not None and self.minValue is not None and self.maxValue is not None:
             type_min, type_max = integral_bounds
             type_name = type(ctype).__name__
 
-            # each bound is checked against both limits, as a decreasing range puts the larger value in
-            # `minValue` and the smaller one in `maxValue`
-            for bound_name, bound_value in (("minValue", self.minValue), ("maxValue", self.maxValue)):
-                # both bounds are populated from the type defaults above, so this only narrows the type
-                if bound_value is None:
-                    continue
+            # a decreasing range puts the larger value in `minValue` and the smaller one in `maxValue`, so
+            # determine which bound is smaller before checking it against the type limits
+            if self.minValue <= self.maxValue:
+                smaller_name, smaller_value = "minValue", self.minValue
+                larger_name, larger_value = "maxValue", self.maxValue
+            else:
+                smaller_name, smaller_value = "maxValue", self.maxValue
+                larger_name, larger_value = "minValue", self.minValue
 
-                if bound_value < type_min:
-                    raise ValueError(
-                        f"`{bound_name}` of {bound_value} is below the minimum value of {type_min} for {type_name}."
-                    )
+            if smaller_value < type_min:
+                raise ValueError(
+                    f"`{smaller_name}` of {smaller_value} is below the minimum allowed {type_name} value {type_min}."
+                )
 
-                if bound_value > type_max:
-                    raise ValueError(
-                        f"`{bound_name}` of {bound_value} is above the maximum value of {type_max} for {type_name}."
-                    )
+            if larger_value > type_max:
+                raise ValueError(
+                    f"`{larger_name}` of {larger_value} is above the maximum allowed {type_name} value {type_max}."
+                )
 
         if isinstance(ctype, (DoubleType, FloatType)) and self.step is None:
             self.step = 1.0

--- a/dbldatagen/nrange.py
+++ b/dbldatagen/nrange.py
@@ -25,9 +25,6 @@ from .serialization import SerializableToDict
 
 _OLD_MIN_OPTION = "min"
 _OLD_MAX_OPTION = "max"
-
-#: inclusive `(minValue, maxValue)` limits of each Spark SQL integral type. These are value limits, so they
-#: are narrower than the count of distinct values checked by `_MAX_TYPE_RANGE` in `column_spec_options`.
 _INTEGRAL_TYPE_BOUNDS: dict[type, tuple[int, int]] = {
     ByteType: (-(2**7), 2**7 - 1),
     ShortType: (-(2**15), 2**15 - 1),
@@ -167,14 +164,14 @@ class NRange(DataRange):
         This will:
 
         - Populate `minValue` and `maxValue` to the default range for the data type
-          if they are not already set.
-        - Validate that `minValue` and `maxValue` are within the representable range of the
+          (i.e. 0 to the maximum representable value) if they are not already set.
+        - Validate that `minValue` and `maxValue` are within the representable range for any
           integral types (`ByteType`, `ShortType`, `IntegerType` and `LongType`).
         - Set a default `step` of 1.0 for floating point types and 1 for integral types
           if `step` is not already set.
 
         :param ctype: Spark SQL data type for the column.
-        :raises ValueError: If `minValue` or `maxValue` is outside the range of an integral `ctype`.
+        :raises ValueError: If `minValue` or `maxValue` is outside the representable range of `ctype`.
         """
         numeric_types = (DecimalType, FloatType, DoubleType, ByteType, ShortType, IntegerType, LongType)
 
@@ -187,13 +184,11 @@ class NRange(DataRange):
                     self.maxValue = numeric_range[1]
 
         integral_bounds = _INTEGRAL_TYPE_BOUNDS.get(type(ctype))
-        # both bounds are already populated from the type defaults above, so this only narrows the type
         if integral_bounds is not None and self.minValue is not None and self.maxValue is not None:
             type_min, type_max = integral_bounds
             type_name = type(ctype).__name__
 
-            # a decreasing range puts the larger value in `minValue` and the smaller one in `maxValue`, so
-            # determine which bound is smaller before checking it against the type limits
+            # Determine which bound is smaller before checking type limits (supports decreasing ranges e.g. (10, 1, -1))
             if self.minValue <= self.maxValue:
                 smaller_name, smaller_value = "minValue", self.minValue
                 larger_name, larger_value = "maxValue", self.maxValue
@@ -302,10 +297,10 @@ class NRange(DataRange):
         :return: Tuple of `(minValue, maxValue)` for the type, or `None` if not supported.
         """
         value_ranges: dict[type, tuple[float | int, float | int]] = {
-            ByteType: (0, (2**4 - 1)),
-            ShortType: (0, (2**8 - 1)),
-            IntegerType: (0, (2**16 - 1)),
-            LongType: (0, (2**32 - 1)),
+            ByteType: (0, (2**7 - 1)),
+            ShortType: (0, (2**15 - 1)),
+            IntegerType: (0, (2**31 - 1)),
+            LongType: (0, (2**63 - 1)),
             FloatType: (0.0, 3.402e38),
             DoubleType: (0.0, 1.79769e308),
         }

--- a/dbldatagen/nrange.py
+++ b/dbldatagen/nrange.py
@@ -194,6 +194,7 @@ class NRange(DataRange):
             # each bound is checked against both limits, as a decreasing range puts the larger value in
             # `minValue` and the smaller one in `maxValue`
             for bound_name, bound_value in (("minValue", self.minValue), ("maxValue", self.maxValue)):
+                # both bounds are populated from the type defaults above, so this only narrows the type
                 if bound_value is None:
                     continue
 

--- a/docs/source/DATARANGES.md
+++ b/docs/source/DATARANGES.md
@@ -49,28 +49,25 @@ we may reduce the range
 
 The following rules apply to any ranged data specifications:
 
-- if the `uniqueValues` option is used, its combined with the any range options to produce the effective range. 
-The number of unique values is given highest priority, but the interval, start and end of the values tries to take 
-into account any range options specified. If the range does not allow for sufficient unique values to be generated, 
-the number of unique values is reduced. 
-- if `values` are specified, the implied range is the set of values for column. Any other range options are ignored
+- If `uniqueValues` is used, it is combined with any range options to produce the effective range. The number of 
+unique values is given highest priority, but the interval, start and end of the values tries to take into account 
+any range options specified. If the range does not allow for sufficient unique values to be generated, the number 
+of unique values is reduced.
+- If `values` are specified, the implied range is the set of values for column. Any other range options are ignored
 - If both a range object is specified and any of the options for `begin`, `end` , `interval` are specified, 
 the relevant value in the range object is used
 - If both a range object is specified and any of the options for `minValue`, `maxValue` , `step` are specified, 
 the relevant value in the range object is used
-- if the range of values conflicts with the underlying data type, the data type values take precedence. For example 
+- If the range of values conflicts with the underlying data type, the data type values take precedence. For example 
 a Boolean field with the range 1 .. 9 will be rescaled to the range 0 .. 1 and still produce both `True` and `False` 
 values
 
 ### Ranges for integral column types
 
-The integral column types are an exception to two of the precedence rules above: the rule that reduces the 
-number of unique values, and the rule that rescales a range conflicting with the data type. The Spark SQL 
-integral types are signed, so the values a column can hold are narrower than the number of distinct values 
-the type provides. Rather than reducing or rescaling a `minValue` or `maxValue` that falls outside the limits 
-in the table below, `build` raises a `ValueError` naming the bound, the limit and the column type. Neither 
-reducing nor rescaling is used here, because both would silently change the range that was asked for, and the 
-values would otherwise wrap around during generation.
+Rather than reducing or rescaling a `minValue`, `maxValue`, or `uniqueValues` that falls outside the limits in 
+the table below, `build` raises a `ValueError` naming the bound, the limit and the column type. Neither reducing 
+nor rescaling is used here, because both would silently change the range that was asked for, and the values would 
+otherwise wrap around during generation.
 
 | Column type | Minimum value | Maximum value |
 |:------------|--------------:|--------------:|
@@ -79,13 +76,10 @@ values would otherwise wrap around during generation.
 | `IntegerType` | -2147483648 | 2147483647 |
 | `LongType` | -9223372036854775808 | 9223372036854775807 |
 
-Each of `minValue` and `maxValue` must fall within the limits for the column type. A decreasing range such 
-as `minValue=127`, `maxValue=1` with a negative `step` is still permitted, since the check does not require 
-`minValue` to be the smaller of the two.
-
-The limits apply however the range is arrived at. A `uniqueValues` count that implies a bound beyond the type 
-limit is reported rather than reduced, and `until` sets `maxValue` one above the value supplied, so 
-`until=127` on a `ByteType` column reports a `maxValue` of 128 and is rejected while `until=126` is accepted.
+Both `minValue` and `maxValue` must fall within the representable range for the requested column type. These 
+limits apply however the range is arrived at. A `uniqueValues` that implies a bound beyond the representable limit 
+is reported rather than reduced, and `until` sets `maxValue` one above the value supplied, so `until=127` on a 
+`ByteType` column reports a `maxValue` of 128 and is rejected while `until=126` is accepted.
 
 ### Handling of dates and timestamps
 

--- a/docs/source/DATARANGES.md
+++ b/docs/source/DATARANGES.md
@@ -64,11 +64,13 @@ values
 
 ### Ranges for integral column types
 
-The integral column types are an exception to the rescaling rule above. The Spark SQL integral types are 
-signed, so the values a column can hold are narrower than the number of distinct values the type provides. 
-Rather than rescaling a `minValue` or `maxValue` that falls outside the limits below, `build` raises a 
-`ValueError` naming the bound, the limit and the column type. Rescaling is not used here because it would 
-silently change the range that was asked for, and the values would otherwise wrap around during generation.
+The integral column types are an exception to two of the precedence rules above: the rule that reduces the 
+number of unique values, and the rule that rescales a range conflicting with the data type. The Spark SQL 
+integral types are signed, so the values a column can hold are narrower than the number of distinct values 
+the type provides. Rather than reducing or rescaling a `minValue` or `maxValue` that falls outside the limits 
+in the table below, `build` raises a `ValueError` naming the bound, the limit and the column type. Neither 
+reducing nor rescaling is used here, because both would silently change the range that was asked for, and the 
+values would otherwise wrap around during generation.
 
 | Column type | Minimum value | Maximum value |
 |:------------|--------------:|--------------:|
@@ -80,6 +82,10 @@ silently change the range that was asked for, and the values would otherwise wra
 Each of `minValue` and `maxValue` must fall within the limits for the column type. A decreasing range such 
 as `minValue=127`, `maxValue=1` with a negative `step` is still permitted, since the check does not require 
 `minValue` to be the smaller of the two.
+
+The limits apply however the range is arrived at. A `uniqueValues` count that implies a bound beyond the type 
+limit is reported rather than reduced, and `until` sets `maxValue` one above the value supplied, so 
+`until=127` on a `ByteType` column reports a `maxValue` of 128 and is rejected while `until=126` is accepted.
 
 ### Handling of dates and timestamps
 

--- a/docs/source/DATARANGES.md
+++ b/docs/source/DATARANGES.md
@@ -62,6 +62,25 @@ the relevant value in the range object is used
 a Boolean field with the range 1 .. 9 will be rescaled to the range 0 .. 1 and still produce both `True` and `False` 
 values
 
+### Ranges for integral column types
+
+The integral column types are an exception to the rescaling rule above. The Spark SQL integral types are 
+signed, so the values a column can hold are narrower than the number of distinct values the type provides. 
+Rather than rescaling a `minValue` or `maxValue` that falls outside the limits below, `build` raises a 
+`ValueError` naming the bound, the limit and the column type. Rescaling is not used here because it would 
+silently change the range that was asked for, and the values would otherwise wrap around during generation.
+
+| Column type | Minimum value | Maximum value |
+|:------------|--------------:|--------------:|
+| `ByteType` | -128 | 127 |
+| `ShortType` | -32768 | 32767 |
+| `IntegerType` | -2147483648 | 2147483647 |
+| `LongType` | -9223372036854775808 | 9223372036854775807 |
+
+Each of `minValue` and `maxValue` must fall within the limits for the column type. A decreasing range such 
+as `minValue=127`, `maxValue=1` with a negative `step` is still permitted, since the check does not require 
+`minValue` to be the smaller of the two.
+
 ### Handling of dates and timestamps
 
 For dates and timestamps, if a number of unique values is specified, these will be generated starting from the start 

--- a/tests/test_quick_tests.py
+++ b/tests/test_quick_tests.py
@@ -511,7 +511,7 @@ class TestQuickTests:
         rng = NRange(maxValue=300)  # above the ByteType maximum of 127
         with pytest.raises(
             ValueError,
-            match=r"`maxValue` of 300 is above the maximum value of 127 for ByteType\.",
+            match=r"`maxValue` of 300 is above the maximum allowed ByteType value 127\.",
         ):
             rng.adjustForColumnDatatype(ByteType())
 
@@ -520,7 +520,7 @@ class TestQuickTests:
         """Test that a `maxValue` above the largest value the column type can hold raises ValueError."""
         rng = NRange(minValue=typeMin, maxValue=typeMax + 1)
         expected = (
-            rf"`maxValue` of {typeMax + 1} is above the maximum value of {typeMax} for {type(columnType).__name__}\."
+            rf"`maxValue` of {typeMax + 1} is above the maximum allowed {type(columnType).__name__} value {typeMax}\."
         )
 
         with pytest.raises(ValueError, match=expected):
@@ -531,7 +531,7 @@ class TestQuickTests:
         """Test that a `minValue` below the smallest value the column type can hold raises ValueError."""
         rng = NRange(minValue=typeMin - 1, maxValue=typeMax)
         expected = (
-            rf"`minValue` of {typeMin - 1} is below the minimum value of {typeMin} for {type(columnType).__name__}\."
+            rf"`minValue` of {typeMin - 1} is below the minimum allowed {type(columnType).__name__} value {typeMin}\."
         )
 
         with pytest.raises(ValueError, match=expected):
@@ -559,7 +559,7 @@ class TestQuickTests:
         rng = NRange(minValue=200, maxValue=1, step=-1)
         with pytest.raises(
             ValueError,
-            match=r"`minValue` of 200 is above the maximum value of 127 for ByteType\.",
+            match=r"`minValue` of 200 is above the maximum allowed ByteType value 127\.",
         ):
             rng.adjustForColumnDatatype(ByteType())
 
@@ -568,7 +568,7 @@ class TestQuickTests:
         rng = NRange(minValue=0, maxValue=-200, step=-1)
         with pytest.raises(
             ValueError,
-            match=r"`maxValue` of -200 is below the minimum value of -128 for ByteType\.",
+            match=r"`maxValue` of -200 is below the minimum allowed ByteType value -128\.",
         ):
             rng.adjustForColumnDatatype(ByteType())
 
@@ -598,7 +598,7 @@ class TestQuickTests:
         """Test that a byte column is rejected when `build` is called, however the out of range bound arrives."""
         data_generator = dg.DataGenerator(sparkSession=spark, name="byte_range", rows=10, partitions=1)
 
-        with pytest.raises(ValueError, match=r"`maxValue` of 200 is above the maximum value of 127 for ByteType\."):
+        with pytest.raises(ValueError, match=r"`maxValue` of 200 is above the maximum allowed ByteType value 127\."):
             data_generator.withColumn("v", ByteType(), **columnOptions).build()
 
     @pytest.mark.parametrize(
@@ -621,7 +621,7 @@ class TestQuickTests:
         rng = NRange(until=127)
         with pytest.raises(
             ValueError,
-            match=r"`maxValue` of 128 is above the maximum value of 127 for ByteType\.",
+            match=r"`maxValue` of 128 is above the maximum allowed ByteType value 127\.",
         ):
             rng.adjustForColumnDatatype(ByteType())
 
@@ -630,7 +630,7 @@ class TestQuickTests:
         rng = NRange(minValue=0.0, maxValue=127.5)
         with pytest.raises(
             ValueError,
-            match=r"`maxValue` of 127.5 is above the maximum value of 127 for ByteType\.",
+            match=r"`maxValue` of 127.5 is above the maximum allowed ByteType value 127\.",
         ):
             rng.adjustForColumnDatatype(ByteType())
 

--- a/tests/test_quick_tests.py
+++ b/tests/test_quick_tests.py
@@ -634,6 +634,30 @@ class TestQuickTests:
         ):
             rng.adjustForColumnDatatype(ByteType())
 
+    @pytest.mark.parametrize(
+        "columnType, typeMax",
+        [
+            (ShortType(), 32767),
+            (IntegerType(), 2147483647),
+            (LongType(), 9223372036854775807),
+            (FloatType(), 3.402e38),
+            (DoubleType(), 1.79769e308),
+            (DecimalType(38, 0), 1e38),
+        ],
+        ids=["short", "int", "long", "float", "double", "decimal"],
+    )
+    def test_default_range_for_random_numeric_column_stays_within_type_range(self, columnType, typeMax):
+        df = (
+            dg.DataGenerator(sparkSession=spark, name="default_range", rows=50000, partitions=4)
+            .withColumn("v", columnType, random=True)
+            .build()
+        )
+
+        bounds = df.selectExpr("min(v) as lo", "max(v) as hi").collect()[0]
+
+        assert bounds["lo"] >= 0
+        assert float(bounds["hi"]) <= typeMax
+
     def test_nrange_get_continuous_range_requires_min_and_max(self):
         rng = NRange(minValue=None, maxValue=10.0)
         with pytest.raises(

--- a/tests/test_quick_tests.py
+++ b/tests/test_quick_tests.py
@@ -585,12 +585,54 @@ class TestQuickTests:
 
         assert rng.maxValue == above_long_max
 
-    def test_nrange_bounds_are_enforced_when_building_a_byte_column(self):
-        """Test that a byte column declaring a `maxValue` of 200 is rejected when `build` is called."""
-        data_generator = dg.DataGenerator(sparkSession=spark, name="byte_range", rows=300, partitions=1)
+    @pytest.mark.parametrize(
+        "columnOptions",
+        [
+            {"minValue": 0, "maxValue": 200, "step": 1},
+            {"uniqueValues": 200},
+            {"dataRange": NRange(minValue=0, maxValue=200, step=1)},
+        ],
+        ids=["maxValue", "uniqueValues", "dataRange"],
+    )
+    def test_nrange_bounds_are_enforced_when_building_a_byte_column(self, columnOptions):
+        """Test that a byte column is rejected when `build` is called, however the out of range bound arrives."""
+        data_generator = dg.DataGenerator(sparkSession=spark, name="byte_range", rows=10, partitions=1)
 
         with pytest.raises(ValueError, match=r"`maxValue` of 200 is above the maximum value of 127 for ByteType\."):
-            data_generator.withColumn("v", ByteType(), minValue=0, maxValue=200, step=1).build()
+            data_generator.withColumn("v", ByteType(), **columnOptions).build()
+
+    @pytest.mark.parametrize(
+        "untilValue, expectedMaxValue",
+        [(125, 126), (126, 127)],
+        ids=["below_limit", "at_limit"],
+    )
+    def test_nrange_until_within_the_type_limit_is_accepted(self, untilValue, expectedMaxValue):
+        """Test that `until` is accepted while the `maxValue` it implies stays within the type limit.
+
+        `until` sets `maxValue` one above the value supplied, so the last accepted value is one below the limit.
+        """
+        rng = NRange(until=untilValue)
+        rng.adjustForColumnDatatype(ByteType())
+
+        assert rng.maxValue == expectedMaxValue
+
+    def test_nrange_until_above_the_type_limit_is_rejected(self):
+        """Test that `until` is rejected once the `maxValue` it implies exceeds the type limit."""
+        rng = NRange(until=127)
+        with pytest.raises(
+            ValueError,
+            match=r"`maxValue` of 128 is above the maximum value of 127 for ByteType\.",
+        ):
+            rng.adjustForColumnDatatype(ByteType())
+
+    def test_nrange_rejects_a_fractional_bound_above_the_type_limit(self):
+        """Test that a fractional bound just above the type limit is rejected rather than truncated."""
+        rng = NRange(minValue=0.0, maxValue=127.5)
+        with pytest.raises(
+            ValueError,
+            match=r"`maxValue` of 127.5 is above the maximum value of 127 for ByteType\.",
+        ):
+            rng.adjustForColumnDatatype(ByteType())
 
     def test_nrange_get_continuous_range_requires_min_and_max(self):
         rng = NRange(minValue=None, maxValue=10.0)

--- a/tests/test_quick_tests.py
+++ b/tests/test_quick_tests.py
@@ -52,6 +52,15 @@ schema = StructType(
 # build spark session
 spark = dg.SparkSingleton.getLocalInstance("quick tests")
 
+# `(column type, minimum value, maximum value)` for each Spark SQL integral type
+integral_type_limits = [
+    (ByteType(), -128, 127),
+    (ShortType(), -32768, 32767),
+    (IntegerType(), -2147483648, 2147483647),
+    (LongType(), -9223372036854775808, 9223372036854775807),
+]
+integral_type_ids = ["byte", "short", "int", "long"]
+
 
 class TestQuickTests:
     """These are a set of quick tests to validate some basic behaviors
@@ -499,12 +508,89 @@ class TestQuickTests:
             _ = rng.getDiscreteRange()
 
     def test_nrange_adjust_for_byte_type_maxvalue_out_of_range(self):
-        rng = NRange(maxValue=300)  # above allowed ByteType max of 256
+        rng = NRange(maxValue=300)  # above the ByteType maximum of 127
         with pytest.raises(
             ValueError,
-            match=r"`maxValue` must be within the valid range \(0 - 256\) for ByteType\.",
+            match=r"`maxValue` of 300 is above the maximum value of 127 for ByteType\.",
         ):
             rng.adjustForColumnDatatype(ByteType())
+
+    @pytest.mark.parametrize("columnType, typeMin, typeMax", integral_type_limits, ids=integral_type_ids)
+    def test_nrange_rejects_maxvalue_above_integral_type_limit(self, columnType, typeMin, typeMax):
+        """Test that a `maxValue` above the largest value the column type can hold raises ValueError."""
+        rng = NRange(minValue=typeMin, maxValue=typeMax + 1)
+        expected = (
+            rf"`maxValue` of {typeMax + 1} is above the maximum value of {typeMax} for {type(columnType).__name__}\."
+        )
+
+        with pytest.raises(ValueError, match=expected):
+            rng.adjustForColumnDatatype(columnType)
+
+    @pytest.mark.parametrize("columnType, typeMin, typeMax", integral_type_limits, ids=integral_type_ids)
+    def test_nrange_rejects_minvalue_below_integral_type_limit(self, columnType, typeMin, typeMax):
+        """Test that a `minValue` below the smallest value the column type can hold raises ValueError."""
+        rng = NRange(minValue=typeMin - 1, maxValue=typeMax)
+        expected = (
+            rf"`minValue` of {typeMin - 1} is below the minimum value of {typeMin} for {type(columnType).__name__}\."
+        )
+
+        with pytest.raises(ValueError, match=expected):
+            rng.adjustForColumnDatatype(columnType)
+
+    @pytest.mark.parametrize("columnType, typeMin, typeMax", integral_type_limits, ids=integral_type_ids)
+    def test_nrange_accepts_the_full_integral_type_range(self, columnType, typeMin, typeMax):
+        """Test that the exact limits of each integral type are accepted and left unchanged."""
+        rng = NRange(minValue=typeMin, maxValue=typeMax)
+        rng.adjustForColumnDatatype(columnType)
+
+        assert rng.minValue == typeMin
+        assert rng.maxValue == typeMax
+
+    def test_nrange_accepts_a_reversed_range_within_the_type_limits(self):
+        """Test that a decreasing range is still accepted when both bounds are within the type limits."""
+        rng = NRange(minValue=127, maxValue=1, step=-1)
+        rng.adjustForColumnDatatype(ByteType())
+
+        assert rng.minValue == 127
+        assert rng.maxValue == 1
+
+    def test_nrange_rejects_a_reversed_range_with_minvalue_above_the_type_limit(self):
+        """Test that a decreasing range is rejected when `minValue` holds the out of range bound."""
+        rng = NRange(minValue=200, maxValue=1, step=-1)
+        with pytest.raises(
+            ValueError,
+            match=r"`minValue` of 200 is above the maximum value of 127 for ByteType\.",
+        ):
+            rng.adjustForColumnDatatype(ByteType())
+
+    def test_nrange_rejects_a_reversed_range_with_maxvalue_below_the_type_limit(self):
+        """Test that a decreasing range is rejected when `maxValue` holds the out of range bound."""
+        rng = NRange(minValue=0, maxValue=-200, step=-1)
+        with pytest.raises(
+            ValueError,
+            match=r"`maxValue` of -200 is below the minimum value of -128 for ByteType\.",
+        ):
+            rng.adjustForColumnDatatype(ByteType())
+
+    @pytest.mark.parametrize(
+        "columnType",
+        [FloatType(), DoubleType(), DecimalType(38, 0)],
+        ids=["float", "double", "decimal"],
+    )
+    def test_nrange_does_not_apply_integral_limits_to_other_numeric_types(self, columnType):
+        """Test that a value above every integral limit is still accepted for a non integral numeric type."""
+        above_long_max = 1e19
+        rng = NRange(minValue=0, maxValue=above_long_max)
+        rng.adjustForColumnDatatype(columnType)
+
+        assert rng.maxValue == above_long_max
+
+    def test_nrange_bounds_are_enforced_when_building_a_byte_column(self):
+        """Test that a byte column declaring a `maxValue` of 200 is rejected when `build` is called."""
+        data_generator = dg.DataGenerator(sparkSession=spark, name="byte_range", rows=300, partitions=1)
+
+        with pytest.raises(ValueError, match=r"`maxValue` of 200 is above the maximum value of 127 for ByteType\."):
+            data_generator.withColumn("v", ByteType(), minValue=0, maxValue=200, step=1).build()
 
     def test_nrange_get_continuous_range_requires_min_and_max(self):
         rng = NRange(minValue=None, maxValue=10.0)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -128,6 +128,16 @@ class TestSerialization:
                     }
                 ],
             ),
+            (
+                pytest.raises(ValueError),
+                [  # Testing serialization error with an NRange maxValue outside the ByteType limit
+                    {
+                        "colName": "col1",
+                        "colType": "byte",
+                        "dataRange": {"kind": "NRange", "minValue": 0, "maxValue": 200},
+                    }
+                ],
+            ),
         ],
     )
     def test_column_definitions_from_dict(self, columns, expectation):


### PR DESCRIPTION
## Changes

NRange.adjustForColumnDatatype compared bounds against the number of distinct values an integral type holds rather than the largest value it can represent, so a byte column accepted a maxValue up to 256 and a short column up to 65536. IntegerType and LongType were unchecked, and minValue was never checked. Such a column wrapped past the type maximum into negative values with ANSI mode off, or failed mid generation with CAST_OVERFLOW with it on. Issue #480 has the reproduction.

The two constants are replaced by a module private table of the signed limits of the four integral types. Each bound is compared against both limits, because a decreasing range puts the larger value in minValue, so checking only one side would leave the overflow reachable through a reversed range such as minValue 200 with maxValue 1. Decreasing ranges remain supported.

This does reject specifications that previously built successfully, whenever the declared bound exceeded the type limit but the row count never reached it. Measured against master, 1 partition:

| specification | before | after |
|---|---|---|
| byte maxValue=200 step=1, 50 rows | built, 0 to 49 | ValueError |
| byte uniqueValues=200, 50 rows | built, 1 to 50 | ValueError |
| short uniqueValues=40000, 100 rows | built, 1 to 100 | ValueError |
| int maxValue=3000000000 step=1, 100 rows | built, 0 to 99 | ValueError |

Each declares a range the column cannot hold and corrupts once the row count grows or random is enabled, so reporting it up front seems the better trade. It does mean uniqueValues is rejected rather than reduced for byte and short, unlike the precedence rule that says unique values are reduced. You asked in #480 whether an out of range bound should raise or be reduced to the type limit; I assumed raising, since that is what this guard already did, but it is a small change either way.

The defaults in _getNumericDataTypeRange for the integral types are widened from the half-bit-width ceiling (byte 0-15, short 0-255, int 0-65535, long 0-4294967295) to the full signed maximum (byte 0-127, short 0-32767, int 0-2147483647, long 0-9223372036854775807), so they sit exactly at the new signed limits rather than well inside them. This is a behavior change: an unbounded integral column, especially with random=True, now draws from the full type range instead of the narrower legacy default. The span check in column_spec_options.py is untouched: it measures maxValue minus minValue against the count of distinct values, and runs earlier at withColumn, so a byte maxValue of 300 still reports its own message. An unused third copy of that table sits at column_generation_spec.py:113 with no readers, left as out of scope. NRange also sets maxValue to until plus 1, so NRange(until=127) on a byte column now reports 128 and is rejected, though until=126 still reaches the top of the type.

### Linked issues

Resolves #480

### Requirements

- [x] manually tested
- [x] updated documentation
- [ ] updated demos (not applicable, this is a bug fix with no new user facing surface)
- [x] updated tests

New tests in tests/test_quick_tests.py cover both bounds for all four integral types, the exact limits in both directions, a decreasing range, both out of range directions, a fractional bound just above a limit, until at and above a limit, and non interference with float, double and decimal. The bounds tests are pure unit tests needing no Spark; one parametrized end to end test covers the three ways an out of range bound arrives, through maxValue, uniqueValues and an explicit dataRange.

make fmt passes (black, ruff, mypy, pylint 10.00/10) and git diff --exit-code is clean afterwards, which is what the CI fmt job checks. make test passes with exit code 0: 1020 passed in the v0 lane, 642 in the core lane, 8 in the faker_pool step, overall coverage 94%. make docs-clean and make docs-build succeed, with the same 8 warnings master already reports.

