### PR TITLE
Fix deserialization of ILText paragraph, sentence and word bounds

### DIFF
--- a/dbldatagen/text_generators.py
+++ b/dbldatagen/text_generators.py
@@ -342,16 +342,16 @@ class TextGenerator(ABC):
     def getAsTupleOrElse(
         v: int | tuple[int, int] | list[int] | None, defaultValue: tuple[int, int], valueName: str = "value"
     ) -> tuple[int, int]:
-        """get value v as tuple or return default value
+        """
+        Gets the input value v as a tuple or returns a tuple of the default value. The default values are
+        returned if the input value is None.
 
-        :param v: value to test. A single value is expanded to a pair, and a 2 element tuple or list is used
-                  as the `(minimum, maximum)` pair.
-        :param defaultValue: value to use as a default if `v` is `None` or otherwise empty
-        :param valueName: name of value for debugging and logging purposes
-        :returns: return `v` as tuple, or `defaultValue` as a tuple if `v` is `None`, zero or empty. If `v` is
-                  a single value, returns the tuple (`v`, `v`)
-        :raises ValueError: If `v` or `defaultValue` is not an integer or a 2 element tuple or list of integers,
-                  is a `bool`, or has a minimum greater than its maximum
+        :param v: Input value; A single value is expanded to a tuple; A 2 element tuple or list is returned unchanged
+        :param defaultValue: Default value to use if `v` is `None` or empty
+        :param valueName: Name of the value for debugging and logging purposes
+        :returns: The input value `v`  as a tuple, or the default value as a tuple if `v` is `None`, zero or empty
+        :raises ValueError: If `v` or `defaultValue` is not an integer, a 2 element tuple, or a 2 element list of
+            integers, if `v` is of type `bool`, or if `v` is a tuple or list with a minimum greater than its maximum
         """
         if not v:
             return TextGenerator._asBoundsPair(defaultValue, "defaultValue")
@@ -360,14 +360,15 @@ class TextGenerator(ABC):
 
     @staticmethod
     def _asBoundsPair(value: int | tuple[int, int] | list[int], valueName: str) -> tuple[int, int]:
-        """Converts a bounds specification to a `(minimum, maximum)` pair of integers.
+        """
+        Converts a bounds specification to a `(minimum, maximum)` pair of integers.
 
-        :param value: a single integer, or a 2 element tuple or list of integers, with the minimum not
+        :param value: A single integer, or a 2 element tuple or list of integers, with the minimum not
                   exceeding the maximum
-        :param valueName: name of the value, used in the error messages
-        :returns: the bounds as a 2 element tuple
-        :raises ValueError: If `value` is not an integer or a 2 element tuple or list of integers, is a
-                  `bool`, or has a minimum greater than its maximum
+        :param valueName: Name of the value, used in the error messages
+        :returns: Bounds as a 2 element tuple
+        :raises ValueError: If `value` is not an integer, a 2 element tuple, or a 2 element list of integers, if
+            `value` is a `bool`, or if `value` is a tuple or list with a minimum greater than its maximum
         """
         if isinstance(value, bool):
             raise ValueError(

--- a/dbldatagen/text_generators.py
+++ b/dbldatagen/text_generators.py
@@ -340,31 +340,43 @@ class TextGenerator(ABC):
 
     @staticmethod
     def getAsTupleOrElse(
-        v: int | tuple[int, int] | None, defaultValue: tuple[int, int], valueName: str = "value"
+        v: int | tuple[int, int] | list[int] | None, defaultValue: tuple[int, int], valueName: str = "value"
     ) -> tuple[int, int]:
         """get value v as tuple or return default value
 
-        :param v: value to test
+        :param v: value to test. A single value is expanded to a pair, and a 2 element tuple or list is used
+                  as the `(minimum, maximum)` pair.
         :param defaultValue: value to use as a default if value of `v` is None. Must be a tuple.
         :param valueName: name of value for debugging and logging purposes
         :returns: return `v` as tuple if not `None` or value of `default_v` if `v` is `None`. If `v` is a single
-                  value, returns the tuple (`v`, `v`)"""
-        assert not v or isinstance(v, int | tuple), f"param {valueName} must be an int, a tuple or None"
-        assert isinstance(defaultValue, tuple) and len(defaultValue) == 2, "default value must be tuple"
+                  value, returns the tuple (`v`, `v`)
+        :raises ValueError: If `v` is not an integer, a 2 element tuple or list, or `None`
 
+        .. note::
+           A bounds pair is written to JSON as an array, so a list is accepted as well as a tuple. This keeps
+           a saved data generation specification loadable, as `loadFromJson` passes the array straight back in.
+        """
         if not v:
-            assert len(defaultValue) == 2, "must have list or iterable with lenght 2"
-            assert isinstance(defaultValue[0], int) and isinstance(
-                defaultValue[1], int
-            ), "all elements must be integers"
             return defaultValue
 
-        if isinstance(v, tuple):
-            assert len(v) == 2, "expecting tuple of length 2"
-            assert isinstance(v[0], int) and isinstance(v[1], int), "expecting tuple with both elements as integers"
-            return v[0], v[1]
+        if isinstance(v, int):
+            return v, v
 
-        return v, v
+        if not isinstance(v, tuple | list):
+            raise ValueError(
+                f"Parameter '{valueName}' must be an integer, a 2 element tuple or list, or None, "
+                f"but a '{type(v).__name__}' was supplied"
+            )
+
+        if len(v) != 2:
+            raise ValueError(
+                f"Parameter '{valueName}' must have exactly 2 elements, but {len(v)} elements were supplied"
+            )
+
+        if not all(isinstance(element, int) for element in v):
+            raise ValueError(f"Parameter '{valueName}' must only contain integer values")
+
+        return v[0], v[1]
 
     @abstractmethod
     def pandasGenerateText(self, v: pd.Series) -> pd.Series:

--- a/dbldatagen/text_generators.py
+++ b/dbldatagen/text_generators.py
@@ -346,33 +346,44 @@ class TextGenerator(ABC):
 
         :param v: value to test. A single value is expanded to a pair, and a 2 element tuple or list is used
                   as the `(minimum, maximum)` pair.
-        :param defaultValue: value to use as a default if value of `v` is None. Must be a tuple.
+        :param defaultValue: value to use as a default if `v` is `None` or otherwise empty
         :param valueName: name of value for debugging and logging purposes
-        :returns: return `v` as tuple if not `None` or value of `defaultValue` if `v` is `None`. If `v` is a single
-                  value, returns the tuple (`v`, `v`)
-        :raises ValueError: If `v` is not an integer, a 2 element tuple or list, or `None`
+        :returns: return `v` as tuple, or `defaultValue` as a tuple if `v` is `None`, zero or empty. If `v` is
+                  a single value, returns the tuple (`v`, `v`)
+        :raises ValueError: If `v` or `defaultValue` is not an integer or a 2 element tuple or list of integers
         """
         if not v:
-            return defaultValue
+            return TextGenerator._asBoundsPair(defaultValue, "defaultValue")
 
-        if isinstance(v, int):
-            return v, v
+        return TextGenerator._asBoundsPair(v, valueName)
 
-        if not isinstance(v, tuple | list):
+    @staticmethod
+    def _asBoundsPair(value: int | tuple[int, int] | list[int], valueName: str) -> tuple[int, int]:
+        """Converts a bounds specification to a `(minimum, maximum)` pair of integers.
+
+        :param value: a single integer, or a 2 element tuple or list of integers
+        :param valueName: name of the value, used in the error messages
+        :returns: the bounds as a 2 element tuple
+        :raises ValueError: If `value` is not an integer or a 2 element tuple or list of integers
+        """
+        if isinstance(value, int):
+            return value, value
+
+        if not isinstance(value, tuple | list):
             raise ValueError(
                 f"Parameter '{valueName}' must be an integer, a 2 element tuple or list, or None, "
-                f"but a '{type(v).__name__}' was supplied"
+                f"but a '{type(value).__name__}' was supplied"
             )
 
-        if len(v) != 2:
+        if len(value) != 2:
             raise ValueError(
-                f"Parameter '{valueName}' must have exactly 2 elements, but {len(v)} elements were supplied"
+                f"Parameter '{valueName}' must have exactly 2 elements, but {len(value)} elements were supplied"
             )
 
-        if not all(isinstance(element, int) for element in v):
+        if not all(isinstance(element, int) for element in value):
             raise ValueError(f"Parameter '{valueName}' must only contain integer values")
 
-        return v[0], v[1]
+        return value[0], value[1]
 
     @abstractmethod
     def pandasGenerateText(self, v: pd.Series) -> pd.Series:
@@ -979,6 +990,8 @@ class ILText(TextGenerator, SerializableToDict):  # lgtm [py/missing-equals]
     :param words: Number of words per sentence to generate. If a 2 element tuple or list is provided, we will
         generate a random number of words in the provided range.
     :param extendedWordList: Optional list of words to use instead of the default Ipsum Lorem list.
+    :raises ValueError: If none of `paragraphs`, `sentences` or `words` is specified, or if one of them is not
+        an integer or a 2 element tuple or list of integers.
     """
 
     def __init__(
@@ -988,9 +1001,8 @@ class ILText(TextGenerator, SerializableToDict):  # lgtm [py/missing-equals]
         words: int | tuple[int, int] | list[int] | None = None,
         extendedWordList: list[str] | None = None,
     ) -> None:
-        assert (
-            paragraphs is not None or sentences is not None or words is not None
-        ), "At least one of the params `paragraphs`, `sentences` or `words` must be specified"
+        if paragraphs is None and sentences is None and words is None:
+            raise ValueError("At least one of the params `paragraphs`, `sentences` or `words` must be specified")
 
         super().__init__()
 

--- a/dbldatagen/text_generators.py
+++ b/dbldatagen/text_generators.py
@@ -348,13 +348,9 @@ class TextGenerator(ABC):
                   as the `(minimum, maximum)` pair.
         :param defaultValue: value to use as a default if value of `v` is None. Must be a tuple.
         :param valueName: name of value for debugging and logging purposes
-        :returns: return `v` as tuple if not `None` or value of `default_v` if `v` is `None`. If `v` is a single
+        :returns: return `v` as tuple if not `None` or value of `defaultValue` if `v` is `None`. If `v` is a single
                   value, returns the tuple (`v`, `v`)
         :raises ValueError: If `v` is not an integer, a 2 element tuple or list, or `None`
-
-        .. note::
-           A bounds pair is written to JSON as an array, so a list is accepted as well as a tuple. This keeps
-           a saved data generation specification loadable, as `loadFromJson` passes the array straight back in.
         """
         if not v:
             return defaultValue
@@ -976,20 +972,20 @@ class ILText(TextGenerator, SerializableToDict):  # lgtm [py/missing-equals]
     """
     This class generates Ipsum Lorem text paragraphs, words, and sentences.
 
-    :param paragraphs: Number of paragraphs to generate. If a tuple is provided, we will generate a random number of
-        paragraphs in the provided range.
-    :param sentences: Number of sentences per paragraph to generate. If a tuple is provided, we will generate a random
-        number of sentences in the provided range.
-    :param words: Number of words per sentence to generate. If a tuple is provided, we will generate a random number of
-        words in the provided range.
+    :param paragraphs: Number of paragraphs to generate. If a 2 element tuple or list is provided, we will generate
+        a random number of paragraphs in the provided range.
+    :param sentences: Number of sentences per paragraph to generate. If a 2 element tuple or list is provided, we
+        will generate a random number of sentences in the provided range.
+    :param words: Number of words per sentence to generate. If a 2 element tuple or list is provided, we will
+        generate a random number of words in the provided range.
     :param extendedWordList: Optional list of words to use instead of the default Ipsum Lorem list.
     """
 
     def __init__(
         self,
-        paragraphs: int | tuple[int, int] | None = None,
-        sentences: int | tuple[int, int] | None = None,
-        words: int | tuple[int, int] | None = None,
+        paragraphs: int | tuple[int, int] | list[int] | None = None,
+        sentences: int | tuple[int, int] | list[int] | None = None,
+        words: int | tuple[int, int] | list[int] | None = None,
         extendedWordList: list[str] | None = None,
     ) -> None:
         assert (

--- a/dbldatagen/text_generators.py
+++ b/dbldatagen/text_generators.py
@@ -350,7 +350,8 @@ class TextGenerator(ABC):
         :param valueName: name of value for debugging and logging purposes
         :returns: return `v` as tuple, or `defaultValue` as a tuple if `v` is `None`, zero or empty. If `v` is
                   a single value, returns the tuple (`v`, `v`)
-        :raises ValueError: If `v` or `defaultValue` is not an integer or a 2 element tuple or list of integers
+        :raises ValueError: If `v` or `defaultValue` is not an integer or a 2 element tuple or list of integers,
+                  is a `bool`, or has a minimum greater than its maximum
         """
         if not v:
             return TextGenerator._asBoundsPair(defaultValue, "defaultValue")
@@ -361,11 +362,19 @@ class TextGenerator(ABC):
     def _asBoundsPair(value: int | tuple[int, int] | list[int], valueName: str) -> tuple[int, int]:
         """Converts a bounds specification to a `(minimum, maximum)` pair of integers.
 
-        :param value: a single integer, or a 2 element tuple or list of integers
+        :param value: a single integer, or a 2 element tuple or list of integers, with the minimum not
+                  exceeding the maximum
         :param valueName: name of the value, used in the error messages
         :returns: the bounds as a 2 element tuple
-        :raises ValueError: If `value` is not an integer or a 2 element tuple or list of integers
+        :raises ValueError: If `value` is not an integer or a 2 element tuple or list of integers, is a
+                  `bool`, or has a minimum greater than its maximum
         """
+        if isinstance(value, bool):
+            raise ValueError(
+                f"Parameter '{valueName}' must be an integer, a 2 element tuple or list, or None, "
+                f"but a 'bool' was supplied"
+            )
+
         if isinstance(value, int):
             return value, value
 
@@ -380,10 +389,14 @@ class TextGenerator(ABC):
                 f"Parameter '{valueName}' must have exactly 2 elements, but {len(value)} elements were supplied"
             )
 
-        if not all(isinstance(element, int) for element in value):
+        if not all(isinstance(element, int) and not isinstance(element, bool) for element in value):
             raise ValueError(f"Parameter '{valueName}' must only contain integer values")
 
-        return value[0], value[1]
+        minimum, maximum = value[0], value[1]
+        if minimum > maximum:
+            raise ValueError(f"Parameter '{valueName}' minimum ({minimum}) must not exceed maximum ({maximum})")
+
+        return minimum, maximum
 
     @abstractmethod
     def pandasGenerateText(self, v: pd.Series) -> pd.Series:

--- a/docs/source/serialized_data_generators.rst
+++ b/docs/source/serialized_data_generators.rst
@@ -109,19 +109,9 @@ To define a column with a text generator, pass a dictionary with the ``TextGener
    }
 
 Options that take a ``(minimum, maximum)`` bounds pair, such as the ``paragraphs``, ``sentences`` and
-``words`` options of ``ILText``, are written to JSON as arrays. Both a two element list and a two element
-tuple are accepted when a saved data generation specification is loaded, so a bounds pair survives a save
-and load cycle unchanged.
-
-.. code-block:: python
-
-   dataSpecOptions = {
-      "name": "users_dataset", "rows": 1000, "randomSeedMethod": "hash_fieldname",
-      "columns": [
-         {"colName": "description", "colType": "string", "text": {
-            "kind": "ILText", "paragraphs": [1, 2], "sentences": [2, 4], "words": [3, 8]}}
-      ]
-   }
+``words`` options of ``ILText``, are written to JSON as arrays, for example ``"words": [3, 8]``. Both a two
+element list and a two element tuple are accepted when a saved data generation specification is loaded, so a
+bounds pair survives a save and load cycle unchanged.
 
 
 To define a column with a text generator, pass a dictionary with the ``TextGenerator`` options.

--- a/docs/source/serialized_data_generators.rst
+++ b/docs/source/serialized_data_generators.rst
@@ -74,7 +74,8 @@ To define a column with a data range, pass a dictionary with the ``DateRange`` o
          {"colName": "user_name", "colType": "string", "expr": "concat('user_', id)"},
          {"colName": "phone_number", "colType": "string", "template": "555-DDD-DDDD"},
          {"colName": "created_on", "colType": "date", "dataRange": {
-            "kind": "DateRange", "begin": "2020-01-01", "end": "2025-01-01", "interval": "1 DAY", "datetime_format": "yyyy-MM-dd"}}
+            "kind": "DateRange", "begin": "2020-01-01", "end": "2025-01-01",
+            "interval": "1 DAY", "datetime_format": "yyyy-MM-dd"}}
       ]
    }
 
@@ -104,14 +105,13 @@ To define a column with a text generator, pass a dictionary with the ``TextGener
          {"colName": "user_name", "colType": "string", "expr": "concat('user_', id)"},
          {"colName": "phone_number", "colType": "string", "template": "555-DDD-DDDD"},
          {"colName": "description", "colType": "string", "text": {
-            "kind": "ILText", "sentences": 3, "words": 10}}
+            "kind": "ILText", "sentences": (3, 5), "words": (3, 10)}}
       ]
    }
 
-Options that take a ``(minimum, maximum)`` bounds pair, such as the ``paragraphs``, ``sentences`` and
-``words`` options of ``ILText``, are written to JSON as arrays, for example ``"words": [3, 8]``. Both a two
-element list and a two element tuple are accepted when a saved data generation specification is loaded, so a
-bounds pair survives a save and load cycle unchanged.
+.. note::
+   Options that take a ``(minimum, maximum)`` bounds pair, such as the ``paragraphs``, ``sentences`` and
+   ``words`` options of ``ILText``, are expressed as arrays (e.g. ``"words": [3, 8]``) when saved as JSON.
 
 
 To define a column with a text generator, pass a dictionary with the ``TextGenerator`` options.

--- a/docs/source/serialized_data_generators.rst
+++ b/docs/source/serialized_data_generators.rst
@@ -108,6 +108,21 @@ To define a column with a text generator, pass a dictionary with the ``TextGener
       ]
    }
 
+Options that take a ``(minimum, maximum)`` bounds pair, such as the ``paragraphs``, ``sentences`` and
+``words`` options of ``ILText``, are written to JSON as arrays. Both a two element list and a two element
+tuple are accepted when a saved data generation specification is loaded, so a bounds pair survives a save
+and load cycle unchanged.
+
+.. code-block:: python
+
+   dataSpecOptions = {
+      "name": "users_dataset", "rows": 1000, "randomSeedMethod": "hash_fieldname",
+      "columns": [
+         {"colName": "description", "colType": "string", "text": {
+            "kind": "ILText", "paragraphs": [1, 2], "sentences": [2, 4], "words": [3, 8]}}
+      ]
+   }
+
 
 To define a column with a text generator, pass a dictionary with the ``TextGenerator`` options.
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -514,6 +514,29 @@ class TestSerialization:
         assert text_generator.sentences == (2, 4)
         assert text_generator.words == (3, 8)
 
+    def test_generator_with_iltext_list_bounds_round_trips(self):
+        """Test that a spec whose ILText bounds arrive as JSON arrays (a list, the form `saveToJson`
+        emits and `loadFromInitializationDict` supplies) loads and normalises back to tuples."""
+        options = {
+            "kind": "DataGenerator",
+            "name": "iltext_list_bounds",
+            "rows": 100,
+            "columns": [
+                {
+                    "colName": "notes",
+                    "colType": "string",
+                    "text": {"kind": "ILText", "paragraphs": [1, 2], "sentences": [2, 4], "words": [3, 8]},
+                }
+            ],
+        }
+
+        reloaded = dg.DataGenerator.loadFromInitializationDict(options)
+        text_generator = reloaded.getColumnSpec("notes").textGenerator
+
+        assert text_generator.paragraphs == (1, 2)
+        assert text_generator.sentences == (2, 4)
+        assert text_generator.words == (3, 8)
+
     def test_from_options(self):
         options = {
             "kind": "ColumnGenerationSpec",

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -135,9 +135,15 @@ class TestSerialization:
                 ],
             ),
             (
-                pytest.raises(ValueError),
+                pytest.raises(ValueError, match="must have exactly 2 elements"),
                 [  # Testing serialization error with an ILText bounds pair of the wrong length
                     {"colName": "col1", "colType": "string", "text": {"kind": "ILText", "paragraphs": [1, 2, 3]}}
+                ],
+            ),
+            (
+                pytest.raises(ValueError, match="At least one of the params"),
+                [  # Testing serialization error with an ILText that specifies no bounds at all
+                    {"colName": "col1", "colType": "string", "text": {"kind": "ILText"}}
                 ],
             ),
         ],

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -54,9 +54,9 @@ class TestSerialization:
                         "text": {"kind": "ILText", "paragraphs": 2, "sentences": 4, "words": 10},
                     },
                     {
-                        # bounds pairs arrive as JSON arrays, which is what `saveToJson` writes for them
                         "colName": "col5",
                         "colType": "string",
+                        # bounds pairs arrive as JSON arrays, which is what `saveToJson` writes for them
                         "text": {"kind": "ILText", "paragraphs": [1, 2], "sentences": [2, 4], "words": [3, 8]},
                     },
                 ],
@@ -132,6 +132,12 @@ class TestSerialization:
                         "colType": "string",
                         "text": {"kind": "InvalidTextFactory", "property": "value"},
                     }
+                ],
+            ),
+            (
+                pytest.raises(ValueError),
+                [  # Testing serialization error with an ILText bounds pair of the wrong length
+                    {"colName": "col1", "colType": "string", "text": {"kind": "ILText", "paragraphs": [1, 2, 3]}}
                 ],
             ),
         ],

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -53,6 +53,12 @@ class TestSerialization:
                         "colType": "string",
                         "text": {"kind": "ILText", "paragraphs": 2, "sentences": 4, "words": 10},
                     },
+                    {
+                        # bounds pairs arrive as JSON arrays, which is what `saveToJson` writes for them
+                        "colName": "col5",
+                        "colType": "string",
+                        "text": {"kind": "ILText", "paragraphs": [1, 2], "sentences": [2, 4], "words": [3, 8]},
+                    },
                 ],
             ),
             (
@@ -482,6 +488,19 @@ class TestSerialization:
         assert column["colName"] == "val"
         assert column["colType"] == "int"
         assert column["expr"] == "id % 12"
+
+    def test_generator_with_iltext_bounds_round_trips(self):
+        """Test that a generator using ILText bounds pairs can be loaded back from its own saved JSON."""
+        gen = dg.DataGenerator(sparkSession=spark, rows=100, name="iltext_bounds").withColumn(
+            "notes", "string", text=dg.ILText(paragraphs=(1, 2), sentences=(2, 4), words=(3, 8))
+        )
+
+        reloaded = dg.DataGenerator.loadFromJson(gen.saveToJson())
+        text_generator = reloaded.getColumnSpec("notes").textGenerator
+
+        assert text_generator.paragraphs == (1, 2)
+        assert text_generator.sentences == (2, 4)
+        assert text_generator.words == (3, 8)
 
     def test_from_options(self):
         options = {

--- a/tests/test_text_generator_basic.py
+++ b/tests/test_text_generator_basic.py
@@ -138,6 +138,18 @@ class TestTextGeneratorBasic:
             TextGenerator.getAsTupleOrElse(boundsValue, (2, 12), "words")
 
     @pytest.mark.parametrize(
+        "defaultValue", ["notatuple", (2, 12, 3), (2.0, 12.0)], ids=["str", "three_elements", "float"]
+    )
+    def test_get_as_tuple_or_else_rejects_an_invalid_default(self, defaultValue):
+        """Test that a default which is not a bounds pair is reported rather than returned unchecked."""
+        with pytest.raises(ValueError, match="Parameter 'defaultValue'"):
+            TextGenerator.getAsTupleOrElse(None, defaultValue, "words")
+
+    def test_get_as_tuple_or_else_expands_a_single_value_default(self):
+        """Test that a single value default is expanded to a pair, as a single value is a valid bounds form."""
+        assert TextGenerator.getAsTupleOrElse(None, 7, "words") == (7, 7)
+
+    @pytest.mark.parametrize(
         "template, expectedOutput",
         [
             (r'53.123.ddd.ddd', r"[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+"),

--- a/tests/test_text_generator_basic.py
+++ b/tests/test_text_generator_basic.py
@@ -137,6 +137,24 @@ class TestTextGeneratorBasic:
         with pytest.raises(ValueError, match="must only contain integer values"):
             TextGenerator.getAsTupleOrElse(boundsValue, (2, 12), "words")
 
+    def test_get_as_tuple_or_else_rejects_a_bool_value(self):
+        """Test that a bool is rejected rather than treated as an int, since bool is a subclass of int."""
+        with pytest.raises(ValueError, match="must be an integer, a 2 element tuple or list, or None"):
+            TextGenerator.getAsTupleOrElse(True, (2, 12), "words")
+
+    @pytest.mark.parametrize("boundsValue", [[True, False], (1, True)], ids=["list", "tuple"])
+    def test_get_as_tuple_or_else_rejects_bool_elements(self, boundsValue):
+        """Test that a bounds pair containing a bool element is rejected rather than accepted as an int."""
+        with pytest.raises(ValueError, match="must only contain integer values"):
+            TextGenerator.getAsTupleOrElse(boundsValue, (2, 12), "words")
+
+    @pytest.mark.parametrize("boundsValue", [(8, 3), [8, 3]], ids=["tuple", "list"])
+    def test_get_as_tuple_or_else_rejects_reversed_bounds(self, boundsValue):
+        """Test that a pair with a minimum greater than its maximum raises ValueError rather than being
+        returned reversed."""
+        with pytest.raises(ValueError, match=r"minimum \(8\) must not exceed maximum \(3\)"):
+            TextGenerator.getAsTupleOrElse(boundsValue, (2, 12), "words")
+
     @pytest.mark.parametrize(
         "defaultValue", ["notatuple", (2, 12, 3), (2.0, 12.0)], ids=["str", "three_elements", "float"]
     )

--- a/tests/test_text_generator_basic.py
+++ b/tests/test_text_generator_basic.py
@@ -106,11 +106,18 @@ class TestTextGeneratorBasic:
             (None, (2, 12)),
             (5, (5, 5)),
             ((3, 8), (3, 8)),
-            ([3, 8], (3, 8)),  # a bounds pair is written to JSON as an array, so it returns as a list
+            ([3, 8], (3, 8)),  # a bounds pair arrives as a list after a JSON round trip
+            (0, (2, 12)),
+            ((), (2, 12)),
+            ([], (2, 12)),
         ],
     )
     def test_get_as_tuple_or_else_accepts_supported_forms(self, boundsValue, expectedTuple):
-        """Test that None, a single value, a 2 element tuple and a 2 element list are all accepted."""
+        """Test that None, a single value, a 2 element tuple and a 2 element list are all accepted.
+
+        A falsy value such as 0 or an empty pair also returns the default, which is the long standing
+        behaviour of this helper.
+        """
         assert TextGenerator.getAsTupleOrElse(boundsValue, (2, 12), "words") == expectedTuple
 
     def test_get_as_tuple_or_else_rejects_unsupported_type(self):

--- a/tests/test_text_generator_basic.py
+++ b/tests/test_text_generator_basic.py
@@ -101,6 +101,36 @@ class TestTextGeneratorBasic:
         assert np_type == expectedType
 
     @pytest.mark.parametrize(
+        "boundsValue, expectedTuple",
+        [
+            (None, (2, 12)),
+            (5, (5, 5)),
+            ((3, 8), (3, 8)),
+            ([3, 8], (3, 8)),  # a bounds pair is written to JSON as an array, so it returns as a list
+        ],
+    )
+    def test_get_as_tuple_or_else_accepts_supported_forms(self, boundsValue, expectedTuple):
+        """Test that None, a single value, a 2 element tuple and a 2 element list are all accepted."""
+        assert TextGenerator.getAsTupleOrElse(boundsValue, (2, 12), "words") == expectedTuple
+
+    def test_get_as_tuple_or_else_rejects_unsupported_type(self):
+        """Test that an unsupported type raises ValueError naming the type that was supplied."""
+        with pytest.raises(ValueError, match="must be an integer, a 2 element tuple or list, or None"):
+            TextGenerator.getAsTupleOrElse("many", (2, 12), "words")
+
+    @pytest.mark.parametrize("boundsValue", [(2, 3, 4), [2, 3, 4], (2,)], ids=["tuple3", "list3", "tuple1"])
+    def test_get_as_tuple_or_else_rejects_wrong_element_count(self, boundsValue):
+        """Test that a bounds pair without exactly 2 elements raises ValueError."""
+        with pytest.raises(ValueError, match="must have exactly 2 elements"):
+            TextGenerator.getAsTupleOrElse(boundsValue, (2, 12), "words")
+
+    @pytest.mark.parametrize("boundsValue", [(2.5, 8), [2, "8"]], ids=["float", "str"])
+    def test_get_as_tuple_or_else_rejects_non_integer_elements(self, boundsValue):
+        """Test that a bounds pair containing a non integer raises ValueError."""
+        with pytest.raises(ValueError, match="must only contain integer values"):
+            TextGenerator.getAsTupleOrElse(boundsValue, (2, 12), "words")
+
+    @pytest.mark.parametrize(
         "template, expectedOutput",
         [
             (r'53.123.ddd.ddd', r"[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+"),


### PR DESCRIPTION
## Changes

ILText takes a (minimum, maximum) bounds pair for its paragraphs, sentences and words options, and docs/source/textdata.rst documents that form. JSON has no tuple type, so saveToJson writes those bounds as arrays and loadFromJson then failed on its own output:

```
AssertionError: param paragraphs must be an int, a tuple or None
```

TextGenerator.getAsTupleOrElse accepted only an integer or a tuple, so the array the library had just written was rejected on the way back in. Under python -O, where assertions are removed, the reload instead succeeded and wrapped each pair in another pair, giving paragraphs of ([1, 2], [1, 2]), which then failed later inside the Python worker rather than at load time. Issue #482 has the full reproduction.

The helper now accepts a two element list as well as a tuple, and each check raises a ValueError naming the parameter instead of asserting, so a malformed bounds pair is reported when the specification is loaded. The normalisation moved into a small private helper so the same messages cover the default as well as the supplied value. The ILText constructor hints and docstring are widened to match, since that is the surface loadFromJson calls, and the bare assert in that constructor is converted to a ValueError for the same reason: it sits on the same load path and vanishes under python -O. utils.mkBoundsList already accepts an integer or a list, so the shape has precedent, but it is not reusable here: it returns a list, defaults only on None, and does not check element types, so consolidating them would change ILText behaviour.

The old code checked the default's length twice, once with a typo, so those duplicated assertions collapse into the same validation path. getAsTupleOrElse is public, so an invalid default now reports a ValueError naming defaultValue rather than returning something that does not match the declared return type.

Specifications that pass ILText scalars behave exactly as before, including the falsy values 0, () and [], which still return the default. No existing test pinned the previous behaviour.

Scope note: this fixes the load failure. A reloaded specification is still not value identical, because every column comes back with random set to true, which is unrelated to ILText and raised separately.

### Linked issues

Resolves #482

### Requirements

- [x] manually tested
- [x] updated documentation
- [ ] updated demos (not applicable, this is a bug fix with no new user facing surface)
- [x] updated tests

New tests in tests/test_text_generator_basic.py cover every accepted form, including a list and the empty defaults, one per rejection branch, and the invalid default cases. tests/test_serialization.py gains a round trip test through saveToJson and loadFromJson, a column using JSON array bounds in the existing fixture, and two error rows so the failures are asserted on the load path with specific messages.

make fmt passes (black, ruff, pylint 10.00/10) and git diff --exit-code is clean afterwards. Note that text_generators.py is on the mypy exclude list, so I am not claiming a mypy result for the changed module. make test passes with exit code 0: 1015 passed in the v0 lane, 642 in the core lane, 8 in the faker_pool step, overall coverage 94% and text_generators.py at 97%. make docs-clean and make docs-build succeed, with the same 8 warnings master already reports.
